### PR TITLE
Feature/blockresolver

### DIFF
--- a/forkable/gates.go
+++ b/forkable/gates.go
@@ -1,0 +1,133 @@
+// Copyright 2019 dfuse Platform Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package forkable
+
+import (
+	"fmt"
+
+	"github.com/dfuse-io/bstream"
+	"go.uber.org/zap"
+)
+
+// This gate lets all blocks through once the target blocknum has passed AS IRREVERSIBLE
+type IrreversibleBlockNumGate struct {
+	Name string
+
+	blockNum uint64
+	handler  bstream.Handler
+	gateType bstream.GateType
+
+	MaxHoldOff      int
+	maxHoldOffCount int
+
+	passed bool
+}
+
+func NewIrreversibleBlockNumGate(blockNum uint64, gateType bstream.GateType, h bstream.Handler) *IrreversibleBlockNumGate {
+	return &IrreversibleBlockNumGate{
+		blockNum:   blockNum,
+		gateType:   gateType,
+		handler:    h,
+		MaxHoldOff: 15000,
+	}
+}
+
+func (g *IrreversibleBlockNumGate) ProcessBlock(blk *bstream.Block, obj interface{}) error {
+	if g.passed {
+		return g.handler.ProcessBlock(blk, obj)
+	}
+
+	fobj := obj.(*ForkableObject)
+	if fobj.Step != StepIrreversible {
+		return nil
+	}
+
+	g.passed = blk.Num() >= g.blockNum
+
+	if (g.blockNum == 0 || g.blockNum == 1) && blk.Num() == 2 {
+		g.gateType = bstream.GateInclusive
+		g.passed = true
+	}
+
+	if !g.passed {
+		if g.MaxHoldOff != 0 {
+			g.maxHoldOffCount++
+			if g.maxHoldOffCount > g.MaxHoldOff {
+				return fmt.Errorf("maximum blocks held off busted: %d", g.MaxHoldOff)
+			}
+		}
+		return nil
+	}
+
+	zlog.Info("irreversible block num gate passed", zap.String("gate_type", g.gateType.String()), zap.Uint64("block_num", g.blockNum))
+
+	if g.gateType == bstream.GateInclusive {
+		return g.handler.ProcessBlock(blk, obj)
+	}
+	return nil
+}
+
+// This gate lets all blocks through once the target block ID has passed AS IRREVERSIBLE
+type IrreversibleBlockIDGate struct {
+	Name string
+
+	blockID  string
+	handler  bstream.Handler
+	gateType bstream.GateType
+
+	MaxHoldOff      int
+	maxHoldOffCount int
+
+	passed bool
+}
+
+func NewIrreversibleBlockIDGate(blockID string, gateType bstream.GateType, h bstream.Handler) *IrreversibleBlockIDGate {
+	return &IrreversibleBlockIDGate{
+		blockID:    blockID,
+		gateType:   gateType,
+		handler:    h,
+		MaxHoldOff: 15000,
+	}
+}
+
+func (g *IrreversibleBlockIDGate) ProcessBlock(blk *bstream.Block, obj interface{}) error {
+	if g.passed {
+		return g.handler.ProcessBlock(blk, obj)
+	}
+
+	g.passed = blk.ID() == g.blockID
+
+	if (g.blockID == "" || g.blockID == "0000000000000000000000000000000000000000000000000000000000000000") && blk.Num() == 2 {
+		g.gateType = bstream.GateInclusive
+		g.passed = true
+	}
+
+	if !g.passed {
+		if g.MaxHoldOff != 0 {
+			g.maxHoldOffCount++
+			if g.maxHoldOffCount > g.MaxHoldOff {
+				return fmt.Errorf("maximum blocks held off busted: %d", g.MaxHoldOff)
+			}
+		}
+		return nil
+	}
+
+	zlog.Info("block id gate passed", zap.String("gate_type", g.gateType.String()), zap.String("block_id", g.blockID))
+
+	if g.gateType == bstream.GateInclusive {
+		return g.handler.ProcessBlock(blk, obj)
+	}
+	return nil
+}

--- a/interfaces.go
+++ b/interfaces.go
@@ -14,6 +14,8 @@
 
 package bstream
 
+import "context"
+
 type Shutterer interface {
 	Shutdown(error)
 	Terminating() <-chan struct{}
@@ -46,13 +48,13 @@ type Source interface { //(with a Handler?)
 // guarantee covering all necessary blocks to handle forks before the block
 // that you want. This requires chain-specific implementations.
 type StartBlockResolver interface {
-	Resolve(targetBlockNum uint64) (startBlockNum uint64, previousIrreversibleID string, err error)
+	Resolve(ctx context.Context, targetBlockNum uint64) (startBlockNum uint64, previousIrreversibleID string, err error)
 }
 
-type StartBlockResolverFunc func(uint64) (uint64, string, error)
+type StartBlockResolverFunc func(context.Context, uint64) (uint64, string, error)
 
-func (s StartBlockResolverFunc) Resolve(targetBlockNum uint64) (uint64, string, error) {
-	return s(targetBlockNum)
+func (s StartBlockResolverFunc) Resolve(ctx context.Context, targetBlockNum uint64) (uint64, string, error) {
+	return s(ctx, targetBlockNum)
 }
 
 type SourceFactory func(h Handler) Source

--- a/interfaces.go
+++ b/interfaces.go
@@ -42,6 +42,19 @@ type Source interface { //(with a Handler?)
 	Shutterer // now an interface! WOW!
 }
 
+// StartBlockResolver should give you a start block number that will
+// guarantee covering all necessary blocks to handle forks before the block
+// that you want. This requires chain-specific implementations.
+type StartBlockResolver interface {
+	Resolve(targetBlockNum uint64) (startBlockNum uint64, previousIrreversibleID string, err error)
+}
+
+type StartBlockResolverFunc func(uint64) (uint64, string, error)
+
+func (s StartBlockResolverFunc) Resolve(targetBlockNum uint64) (uint64, string, error) {
+	return s(targetBlockNum)
+}
+
 type SourceFactory func(h Handler) Source
 type SourceFromRefFactory func(startBlockRef BlockRef, h Handler) Source
 type SourceFromNumFactory func(startBlockNum uint64, h Handler) Source

--- a/interfaces.go
+++ b/interfaces.go
@@ -47,6 +47,19 @@ type Source interface { //(with a Handler?)
 // StartBlockResolver should give you a start block number that will
 // guarantee covering all necessary blocks to handle forks before the block
 // that you want. This requires chain-specific implementations.
+//
+// A StartBlockResolver helps determine what is the lowest block that you
+// have to fetch from your block source to ensure that you can handle forks
+// for a given target start block
+//
+// ex: I want to start at block 1000 and I may have to start at block 700 if
+// I don't have knowledge of which block 1000 is "irreversible")
+//  * the DumbStartBlockResolver may simply tell you to start at block 500 and be done with it.
+//  * a StartBlockResolver based on more data could tell you that you can start at block 1000
+//    but that you need to set the irreversible ID to "00001000deadbeef" in your `forkable`
+//    (InclusiveLIB) so that you don't start on a forked block that can't be resolved
+//  * a StartBlockResolver based on a blocksource for EOSIO could fetch the "dposLIBNum"
+//    of your targetStartBlock, and tell you to start at that block (ex: 727)
 type StartBlockResolver interface {
 	Resolve(ctx context.Context, targetBlockNum uint64) (startBlockNum uint64, previousIrreversibleID string, err error)
 }

--- a/util.go
+++ b/util.go
@@ -15,6 +15,7 @@
 package bstream
 
 import (
+	"context"
 	"encoding/binary"
 	"encoding/hex"
 	"fmt"
@@ -59,7 +60,7 @@ func toBlockNum(blockID string) uint64 {
 
 // DumbStartBlockResolver will help you start x blocks before your target start block
 func DumbStartBlockResolver(precedingBlocks uint64) StartBlockResolverFunc {
-	return func(targetBlockNum uint64) (uint64, string, error) {
+	return func(_ context.Context, targetBlockNum uint64) (uint64, string, error) {
 		if targetBlockNum <= precedingBlocks {
 			return 0, "", nil
 		}

--- a/util.go
+++ b/util.go
@@ -127,7 +127,6 @@ func ParallelResolveStartBlock(ctx context.Context, targetStartBlockNum uint64, 
 		case <-ctx.Done():
 			return 0, "", ctx.Err()
 		case resp := <-outChan:
-			fmt.Println("GOT AN ANSWER FROM REESP", resp.startBlockNum, resp.previousIrreversibleID)
 			if resp.errs == nil {
 				return resp.startBlockNum, resp.previousIrreversibleID, nil
 			}

--- a/util.go
+++ b/util.go
@@ -56,3 +56,13 @@ func toBlockNum(blockID string) uint64 {
 	}
 	return binary.BigEndian.Uint64(bin)
 }
+
+// DumbStartBlockResolver will help you start x blocks before your target start block
+func DumbStartBlockResolver(precedingBlocks uint64) StartBlockResolverFunc {
+	return func(targetBlockNum uint64) (uint64, string, error) {
+		if targetBlockNum <= precedingBlocks {
+			return 0, "", nil
+		}
+		return targetBlockNum - precedingBlocks, "", nil
+	}
+}


### PR DESCRIPTION
add StartBlockResolver interface and ParallelResolveStartBlock(..., resolvers) helper

A StartBlockResolver helps determine what is the lowest block that you have to fetch from your block source to ensure that you can handle forks for a given target start block (ex: I want to start at block 1000 and I may have to start at block 700 if I don't have knowledge of which block 1000 is "irreversible")

Ex: 
* the DumbStartBlockResolver may simply tell you to start at block 500 and be done with it.
* a StartBlockResolver based on more data could tell you that you can start at block 1000 but that you need to set the irreversible ID to "00001000deadbeef" in your forkable (Inclusive) so that you don't start on a forked block that can't be resolved
* a startBlockResolver based on a blocksource for EOSIO could fetch the "dposLIBNum" of your targetStartBlock, and tell you to start at that block (ex: 727)

 