### PR TITLE
DO NOT MERGE tracker feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- `Tracker` object to streamline queries about different targets (like network head, database lib, relayer blockstream head, whatever other BlockRef tags), ask the question about them being near one another (to select between live mode or catch-up mode).  Also streamlines the requests of a start block, with a bunch of different backend implementations that can answer to the questions regarding where to start.
+- `JoiningSourceWithTracker` to avoid joining to live when live and file sources are very far apart.
+- `HeadBlockRefGetter` and `LIBBlockRefGetter` that targets a `HeadInfo` service, and satisfies the `Tracker` _BlockRefGetter_ func signature.
+
 ## [v0.0.1] - 2020-06-22
 
 ### Added

--- a/headinfo.go
+++ b/headinfo.go
@@ -1,0 +1,55 @@
+package bstream
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/dfuse-io/dgrpc"
+	pbheadinfo "github.com/dfuse-io/pbgo/dfuse/headinfo/v1"
+)
+
+func LIBBlockRefGetter(headinfoServiceAddr string) BlockRefGetter {
+	return blockRefGetter(headinfoServiceAddr, func(resp *pbheadinfo.HeadInfoResponse) BlockRef {
+		return &BasicBlockRef{
+			id:  resp.LibID,
+			num: resp.LibNum,
+		}
+	})
+}
+
+func HeadBlockRefGetter(headinfoServiceAddr string) BlockRefGetter {
+	return blockRefGetter(headinfoServiceAddr, func(resp *pbheadinfo.HeadInfoResponse) BlockRef {
+		return &BasicBlockRef{
+			id:  resp.HeadID,
+			num: resp.HeadNum,
+		}
+	})
+}
+
+func blockRefGetter(headinfoServiceAddr string, extract func(resp *pbheadinfo.HeadInfoResponse) BlockRef) BlockRefGetter {
+	var lock sync.Mutex
+	var headinfoCli pbheadinfo.HeadInfoClient
+
+	return func(ctx context.Context) (BlockRef, error) {
+		lock.Lock()
+		defer lock.Unlock()
+
+		if headinfoCli == nil {
+			conn, err := dgrpc.NewInternalClient(headinfoServiceAddr)
+			if err != nil {
+				return nil, fmt.Errorf("reaching out to headinfo service %q: %w", headinfoServiceAddr, err)
+			}
+			headinfoCli = pbheadinfo.NewHeadInfoClient(conn)
+		}
+
+		resp, err := headinfoCli.GetHeadInfo(ctx, &pbheadinfo.HeadInfoRequest{})
+		if err == nil && resp.HeadNum != 0 {
+			return extract(resp), nil
+		}
+		// TODO: distinguish the remote `NotFound` and another error, return `NotFound` is it was
+		// indeed not found, and its not another type of error.
+		return nil, ErrTrackerBlockNotFound
+
+	}
+}

--- a/headinfo.go
+++ b/headinfo.go
@@ -43,10 +43,13 @@ func blockRefGetter(headinfoServiceAddr string, extract func(resp *pbheadinfo.He
 			headinfoCli = pbheadinfo.NewHeadInfoClient(conn)
 		}
 
+		// TODO: implement the `NETWORK` and `STREAM` and `DB` query kinds, for when we query
+		// blockmeta, which can answer all of those things.
 		resp, err := headinfoCli.GetHeadInfo(ctx, &pbheadinfo.HeadInfoRequest{})
 		if err == nil && resp.HeadNum != 0 {
 			return extract(resp), nil
 		}
+
 		// TODO: distinguish the remote `NotFound` and another error, return `NotFound` is it was
 		// indeed not found, and its not another type of error.
 		return nil, ErrTrackerBlockNotFound

--- a/hub/hub.go
+++ b/hub/hub.go
@@ -15,6 +15,7 @@
 package hub
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"sync"
@@ -86,7 +87,15 @@ func (h *SubscriptionHub) HeadBlock() bstream.BlockRef {
 	if head == nil {
 		return nil
 	}
-	return head.(bstream.BlockRef)
+	return head
+}
+
+func (h *SubscriptionHub) HeadTracker(_ context.Context) (bstream.BlockRef, error) {
+	res := h.HeadBlock()
+	if res == nil {
+		return nil, bstream.ErrTrackerBlockNotFound
+	}
+	return res, nil
 }
 
 func (h *SubscriptionHub) Launch() {

--- a/interfaces.go
+++ b/interfaces.go
@@ -14,8 +14,6 @@
 
 package bstream
 
-import "context"
-
 type Shutterer interface {
 	Shutdown(error)
 	Terminating() <-chan struct{}
@@ -44,38 +42,10 @@ type Source interface { //(with a Handler?)
 	Shutterer // now an interface! WOW!
 }
 
-// StartBlockResolver should give you a start block number that will
-// guarantee covering all necessary blocks to handle forks before the block
-// that you want. This requires chain-specific implementations.
-//
-// A StartBlockResolver helps determine what is the lowest block that you
-// have to fetch from your block source to ensure that you can handle forks
-// for a given target start block
-//
-// ex: I want to start at block 1000 and I may have to start at block 700 if
-// I don't have knowledge of which block 1000 is "irreversible")
-//  * the DumbStartBlockResolver may simply tell you to start at block 500 and be done with it.
-//  * a StartBlockResolver based on more data could tell you that you can start at block 1000
-//    but that you need to set the irreversible ID to "00001000deadbeef" in your `forkable`
-//    (InclusiveLIB) so that you don't start on a forked block that can't be resolved
-//  * a StartBlockResolver based on a blocksource for EOSIO could fetch the "dposLIBNum"
-//    of your targetStartBlock, and tell you to start at that block (ex: 727)
-type StartBlockResolver interface {
-	Resolve(ctx context.Context, targetBlockNum uint64) (startBlockNum uint64, previousIrreversibleID string, err error)
-}
-
-type StartBlockResolverFunc func(context.Context, uint64) (uint64, string, error)
-
-func (s StartBlockResolverFunc) Resolve(ctx context.Context, targetBlockNum uint64) (uint64, string, error) {
-	return s(ctx, targetBlockNum)
-}
-
 type SourceFactory func(h Handler) Source
 type SourceFromRefFactory func(startBlockRef BlockRef, h Handler) Source
 type SourceFromNumFactory func(startBlockNum uint64, h Handler) Source
 type SourceFromNumFactoryWithErr func(startBlockNum uint64, h Handler) (Source, error)
-
-type StartBlockGetter func() (blockNum uint64)
 
 // Subscriber is a live blocks subscriber implementation
 type Subscriber interface {

--- a/joiningsource.go
+++ b/joiningsource.go
@@ -21,9 +21,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/dfuse-io/logging"
-
 	"github.com/dfuse-io/dgrpc"
+	"github.com/dfuse-io/logging"
 	pbbstream "github.com/dfuse-io/pbgo/dfuse/bstream/v1"
 	pbmerger "github.com/dfuse-io/pbgo/dfuse/merger/v1"
 	"github.com/dfuse-io/shutter"
@@ -248,17 +247,17 @@ func (s *JoiningSource) run() error {
 					s.Shutdown(nil)
 				}
 			})
-			s.tracker.AddFetcher("filesource", tracker.FetcherFunc(func() (BlockRef, error) {
+			s.tracker.AddGetter(FileSourceHeadTarget, func(ctx context.Context) (BlockRef, error) {
 				if s.lastFileProcessedBlockID != "" {
-					return NewSimpleBlockRefFromID(s.lastFileProcessedBlockID), nil
+					return NewBlockRefFromID(s.lastFileProcessedBlockID), nil
 				}
-				return nil, tracker.NotFound
-			}))
-			s.tracker.AddFetcher("livesource", tracker.FetcherFunc(func() (BlockRef, error) {
+				return nil, TrackerNotFound
+			})
+			s.tracker.AddGetter(LiveSourceHeadTarget, GetFunc(func(ctx context.Context) (BlockRef, error) {
 				if s.lastFileProcessedBlockID != "" {
-					return NewSimpleBlockRefFromID(s.lastFileProcessedBlockID), nil
+					return NewBlockRefFromID(s.lastFileProcessedBlockID), nil
 				}
-				return nil, tracker.NotFound
+				return nil, TrackerNotFound
 			}))
 
 			joiningSourceLogger.Info("Joining Source: calling run on live source", zap.String("name", s.name))

--- a/logging.go
+++ b/logging.go
@@ -1,4 +1,4 @@
-// Copyright 2019 dfuse Platform Inc.
+// Copyright 2020 dfuse Platform Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tracker.go
+++ b/tracker.go
@@ -1,0 +1,281 @@
+package bstream
+
+/**
+
+
+Usage:
+
+	a.tracker.AddGetter(bstream.StreamHeadTarget, dexer.Hub)
+	a.tracker.AddGetter(bstream.StreamHeadTarget, timeline.ParallelGetter(relayerClient.GetterFactory(a.config.RelayerAddr), blockmeta.TrackerGetterFactory(a.config.BlockmetaAddr)))
+	a.tracker.AddGetter(bstream.StreamHeadTarget, codec.GetterFactory(eosAPI))
+	//a.tracker.AddGetter(dmesh.ArchiveHeadTarget, dmesh.TrackerGetterFactory(dmeshServer))
+	// dmesh/interface.go
+	// const ArchiveTailTarget = dtrack.Target("archive-tail")
+	blockRef, err := a.tracker.Latest(dmesh.ArchiveTailTarget)
+
+REVIEW THE ABOVE.. find a nice pattern ^^
+*/
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+//
+// Types to support the Tracker
+//
+
+// GetBlockRefFunc is a function to retrieve a block ref from any system.
+type GetBlockRefFunc func(context.Context) (BlockRef, error)
+
+// StartBlockResolver should give you a start block number that will
+// guarantee covering all necessary blocks to handle forks before the block
+// that you want. This requires chain-specific implementations.
+//
+// A StartBlockResolver helps determine what is the lowest block that you
+// have to fetch from your block source to ensure that you can handle forks
+// for a given target start block
+//
+// ex: I want to start at block 1000 and I may have to start at block 700 if
+// I don't have knowledge of which block 1000 is "irreversible")
+//  * the DumbStartBlockResolver may simply tell you to start at block 500 and be done with it.
+//  * a StartBlockResolver based on more data could tell you that you can start at block 1000
+//    but that you need to set the irreversible ID to "00001000deadbeef" in your `forkable`
+//    (InclusiveLIB) so that you don't start on a forked block that can't be resolved
+//  * a StartBlockResolver based on a blocksource for EOSIO could fetch the "dposLIBNum"
+//    of your targetStartBlock, and tell you to start at that block (ex: 727)
+type StartBlockResolverFunc func(ctx context.Context, targetBlockNum uint64) (startBlockNum uint64, previousIrreversibleID string, err error)
+
+var TrackerNotFound = errors.New("tracker not found")
+
+type Target string
+
+const (
+	FileSourceHeadTarget  = Target("filesource-head")
+	LiveSourceHeadTarget  = Target("livesource-head")
+	LiveSourceTailTarget  = Target("livesource-tail")
+	NetworkHeadTarget     = Target("network-head")
+	NetworkLIBTarget      = Target("network-lib")
+	BlockStreamHeadTarget = Target("bstream-head")
+	BlockStreamLIBTarget  = Target("bstream-lib")
+	HubHeadTarget         = Target("hub-head")
+	HubLIBTarget          = Target("hub-lib")
+	// DatabaseHeadTarget    = Target("db-head")
+	// DmeshTailTarget       = Target("dmesh-tail")
+	// DmeshHeadTarget       = Target("dmesh-head")
+)
+
+// Tracker tracks the chain progress and block history. Allows many
+// processes to take decisions on the state of different pieces being
+// sync'd (live) or in catch-up mode.
+type Tracker struct {
+	getters   map[Target][]GetBlockRefFunc
+	resolvers []StartBlockResolverFunc
+
+	// Number of blocks between two targets before we consider the
+	// first as "live" towards the second. For example: a stream to be
+	// live, when compared to the network's latest block.
+	nearBlocksCount int64
+}
+
+func NewTracker(nearBlocksCount uint64) *Tracker {
+	return &Tracker{
+		getters:         make(map[Target][]GetBlockRefFunc),
+		nearBlocksCount: int64(nearBlocksCount),
+	}
+}
+
+func (t *Tracker) AddGetter(target Target, f GetBlockRefFunc) {
+	t.getters[target] = append(t.getters[target], f)
+}
+
+// AddResolver adds a start block resolver
+func (t *Tracker) AddResolver(resolver StartBlockResolverFunc) {
+	t.resolvers = append(t.resolvers, resolver)
+}
+
+func (t *Tracker) IsNear(ctx context.Context, from Target, to Target) (bool, error) {
+	fromBlk, err := t.Get(ctx, from)
+	if err != nil {
+		return false, err
+	}
+
+	toBlk, err := t.Get(ctx, to)
+	if err != nil {
+		return false, err
+	}
+
+	if int64(toBlk.Num())-int64(fromBlk.Num()) < t.nearBlocksCount {
+		return true, nil
+	}
+
+	return false, nil
+}
+
+func (t *Tracker) Get(ctx context.Context, target Target) (BlockRef, error) {
+	getters := t.getters[target]
+	if len(getters) == 0 {
+		return nil, fmt.Errorf("no getters for target type %q", target)
+	}
+	var errs []string
+	for _, f := range getters {
+		ref, err := f(ctx)
+		if err != nil {
+			errs = append(errs, err.Error())
+			continue
+		}
+		return ref, nil
+	}
+
+	return nil, errors.New("tracking fetch errors in order: " + strings.Join(errs, ", "))
+}
+
+// ResolveStartBlock gives you previous references to start processing
+// in a fork-aware manner. forkDBInitRef is guaranteed to have a Num()
+// if forkDBInitRef has an ID, you SetLIB() on the ForkDB with it.
+func (t *Tracker) ResolveStartBlock(ctx context.Context, targetBlockNum uint64) (startBlockNum uint64, previousIrreversibleID string, err error) {
+	if len(t.resolvers) == 0 {
+		err = fmt.Errorf("no resolvers configured")
+		return
+	}
+	var errs []string
+	for _, f := range t.resolvers {
+		startBlockNum, previousIrreversibleID, err = f(ctx, targetBlockNum)
+		if err != nil {
+			errs = append(errs, err.Error())
+			continue
+		}
+		return
+	}
+	err = errors.New("resolving block reference: " + strings.Join(errs, ", "))
+	return
+
+	// Potential implementations:
+	//
+	// Fetch from blockmeta, ask for irreversible block at startBlock height.
+	//   If blockmeta doesn't have it irreversible at that height, it could
+	//   return the irreversible block prior to the requested startBlock
+	// Fetch from blocks logs which includes blocks logs, inspect it
+	//   and return the dposlib num we find in there.
+	// Fetch from blkdb for all blocks at a given number,
+	//   fetch whether any of those is irreversible
+	// Fetch from blkdb for the given block number
+	//   and return its dposlib num
+	// Dmesh based LIB for the given number
+	// Dummy resolver, merely returns blocks from the past.
+}
+
+func (t *Tracker) ResolveRelativeBlock(ctx context.Context, potentiallyNegativeBlockNum int64, target Target) (uint64, error) {
+	if potentiallyNegativeBlockNum < 0 {
+		blk, err := t.Get(ctx, target)
+		if err != nil {
+			return 0, err
+		}
+		return uint64(int64(blk.Num()) + potentiallyNegativeBlockNum), nil
+	}
+	return uint64(potentiallyNegativeBlockNum), nil
+}
+
+func ParallelGetBlockRefFunc(f ...GetBlockRefFunc) GetBlockRefFunc {
+	return func(ctx context.Context) (BlockRef, error) {
+		// launch all `f` in parallel, first to finish returns its value
+		return nil, nil
+	}
+}
+
+// ParallelStartResolver will call multiple resolvers to get the fastest answer.
+func ParallelBlockResolver(resolvers ...StartBlockResolverFunc) StartBlockResolverFunc {
+	type resolveStartBlockResp struct {
+		startBlockNum          uint64
+		previousIrreversibleID string
+		err                    error
+	}
+
+	return func(ctx context.Context, targetBlockNum uint64) (startBlockNum uint64, previousIrreversibleID string, err error) {
+		ctx, cancel := context.WithCancel(ctx)
+		defer cancel()
+
+		outChan := make(chan *resolveStartBlockResp)
+		for _, resolver := range resolvers {
+			go func() {
+				startBlockNum, previousIrreversibleID, err := resolver(ctx, targetBlockNum)
+				resp := &resolveStartBlockResp{
+					startBlockNum:          startBlockNum,
+					previousIrreversibleID: previousIrreversibleID,
+					err:                    err,
+				}
+				select {
+				case outChan <- resp:
+				case <-ctx.Done():
+				}
+			}()
+		}
+
+		var errs []string
+		for cnt := 0; cnt < len(resolvers); cnt++ {
+			select {
+			case <-ctx.Done():
+				return 0, "", ctx.Err()
+			case resp := <-outChan:
+				if resp.err != nil {
+					errs = append(errs, resp.err.Error())
+				} else {
+					return resp.startBlockNum, resp.previousIrreversibleID, nil
+				}
+			}
+		}
+
+		return 0, "", errors.New("all parallel resolvers failed: " + strings.Join(errs, ", "))
+	}
+}
+
+func RetryableBlockResolver(attempts int, next StartBlockResolverFunc) StartBlockResolverFunc {
+	return func(ctx context.Context, targetBlockNum uint64) (startBlockNum uint64, previousIrreversibleID string, err error) {
+		var errs []string
+		for attempt := 0; attempts == -1 || attempt <= attempts; attempt++ {
+			if err = ctx.Err(); err != nil {
+				errs = append(errs, err.Error())
+				break
+			}
+
+			startBlockNum, previousIrreversibleID, err = next(ctx, targetBlockNum)
+			if err != nil {
+				zlog.Debug("got an error from a block resolver", zap.Error(err))
+				errs = append(errs, err.Error())
+				attempt++
+				time.Sleep(time.Second)
+				continue
+			}
+
+			zlog.Debug("resolved start block num", zap.Uint64("target_start_block_num", targetBlockNum), zap.Uint64("start_block_num", startBlockNum), zap.String("previous_irreversible_id", previousIrreversibleID))
+		}
+		err = fmt.Errorf("retryable resolver failed: %s", strings.Join(errs, ", "))
+		return
+	}
+}
+
+// func CachedStartBlockResolver(f StartBlockResolverFunc) StartBlockResolverFunc {
+// 	var lastElements []uint64
+// 	resolvedRefs := map[uint64]BlockRef{}
+
+// 	return func(ctx context.Context, targetBlockNum uint64) {
+
+// 	}
+// }
+
+var DumbStartBlockResolver = OffsetStartBlockResolver
+
+// OffsetStartBlockResolver will help you start x blocks before your target start block
+func OffsetStartBlockResolver(precedingBlocks uint64) StartBlockResolverFunc {
+	return func(_ context.Context, targetBlockNum uint64) (uint64, string, error) {
+		if targetBlockNum <= precedingBlocks {
+			return 0, "", nil
+		}
+		return targetBlockNum - precedingBlocks, "", nil
+	}
+}

--- a/tracker.go
+++ b/tracker.go
@@ -30,8 +30,8 @@ import (
 // Types to support the Tracker
 //
 
-// GetBlockRefFunc is a function to retrieve a block ref from any system.
-type GetBlockRefFunc func(context.Context) (BlockRef, error)
+// BlockRefGetter is a function to retrieve a block ref from any system.
+type BlockRefGetter func(context.Context) (BlockRef, error)
 
 // StartBlockResolver should give you a start block number that will
 // guarantee covering all necessary blocks to handle forks before the block
@@ -75,7 +75,7 @@ const (
 // processes to take decisions on the state of different pieces being
 // sync'd (live) or in catch-up mode.
 type Tracker struct {
-	getters   map[Target][]GetBlockRefFunc
+	getters   map[Target][]BlockRefGetter
 	resolvers []StartBlockResolverFunc
 
 	// Number of blocks between two targets before we consider the
@@ -86,12 +86,12 @@ type Tracker struct {
 
 func NewTracker(nearBlocksCount uint64) *Tracker {
 	return &Tracker{
-		getters:         make(map[Target][]GetBlockRefFunc),
+		getters:         make(map[Target][]BlockRefGetter),
 		nearBlocksCount: int64(nearBlocksCount),
 	}
 }
 
-func (t *Tracker) AddGetter(target Target, f GetBlockRefFunc) {
+func (t *Tracker) AddGetter(target Target, f BlockRefGetter) {
 	t.getters[target] = append(t.getters[target], f)
 }
 
@@ -191,7 +191,7 @@ func (t *Tracker) ResolveRelativeBlock(ctx context.Context, potentiallyNegativeB
 	return uint64(potentiallyNegativeBlockNum), nil
 }
 
-func ParallelGetBlockRefFunc(f ...GetBlockRefFunc) GetBlockRefFunc {
+func ParallelBlockRefGetter(f ...BlockRefGetter) BlockRefGetter {
 	return func(ctx context.Context) (BlockRef, error) {
 		// launch all `f` in parallel, first to finish returns its value
 		return nil, nil

--- a/tracker.go
+++ b/tracker.go
@@ -51,7 +51,8 @@ type GetBlockRefFunc func(context.Context) (BlockRef, error)
 //    of your targetStartBlock, and tell you to start at that block (ex: 727)
 type StartBlockResolverFunc func(ctx context.Context, targetBlockNum uint64) (startBlockNum uint64, previousIrreversibleID string, err error)
 
-var TrackerNotFound = errors.New("tracker not found")
+var ErrTrackerBlockNotFound = errors.New("tracker block not found")
+var ErrGetterUndefined = errors.New("tracker getter not defined for given target")
 
 type Target string
 
@@ -120,7 +121,7 @@ func (t *Tracker) IsNear(ctx context.Context, from Target, to Target) (bool, err
 func (t *Tracker) Get(ctx context.Context, target Target) (BlockRef, error) {
 	getters := t.getters[target]
 	if len(getters) == 0 {
-		return nil, fmt.Errorf("no getters for target type %q", target)
+		return nil, ErrGetterUndefined
 	}
 	var errs []string
 	for _, f := range getters {

--- a/tracker.go
+++ b/tracker.go
@@ -79,8 +79,8 @@ type Tracker struct {
 	resolvers []StartBlockResolverFunc
 
 	// Number of blocks between two targets before we consider the
-	// first as "live" towards the second. For example: a stream to be
-	// live, when compared to the network's latest block.
+	// first as "near" the second. Like a relayer stream being near
+	// the tip of the network.
 	nearBlocksCount int64
 }
 
@@ -134,6 +134,14 @@ func (t *Tracker) Get(ctx context.Context, target Target) (BlockRef, error) {
 	}
 
 	return nil, errors.New("tracking fetch errors in order: " + strings.Join(errs, ", "))
+
+	// Get from EOS API
+	// Get from HeadInfo from any service ()
+	// Get from SubscriptionHub  (use `tracker.AddGetter(bstream.StreamHeadTarget, hub.HeadTracker)`)
+	// Get from blockmeta
+	// Get from blkdb/trxdb's last written block
+	// Get from fluxdb's latest written block
+	// Get from command-line checkpoint?
 }
 
 // ResolveStartBlock gives you previous references to start processing
@@ -169,6 +177,7 @@ func (t *Tracker) ResolveStartBlock(ctx context.Context, targetBlockNum uint64) 
 	//   and return its dposlib num
 	// Dmesh based LIB for the given number
 	// Dummy resolver, merely returns blocks from the past.
+	// Command-line source for a num + ID where to start.
 }
 
 func (t *Tracker) ResolveRelativeBlock(ctx context.Context, potentiallyNegativeBlockNum int64, target Target) (uint64, error) {
@@ -280,3 +289,23 @@ func OffsetStartBlockResolver(precedingBlocks uint64) StartBlockResolverFunc {
 		return targetBlockNum - precedingBlocks, "", nil
 	}
 }
+
+// type GetInfoTwoCallsCache struct {
+// 	api *eos.API
+// 	lastCall time.Time
+// 	cachedLastCall *eos.InfoResp
+// }
+
+// func init() {
+// 	cacher := &GetInfo..{}
+// 	tracker.AddGetter(bstream.StreamHeadTarget, cacher.StreamHeadGetter)
+// 	tracker.AddGetter(bstream.StreamLIBTarget, cacher.StreamLIBGetter)
+// }
+
+// func (c *GetInfoTwoCallsCache) StreamHeadGetter() BlockRefGetterFunc {
+// 	if time.Since(lastCall) < 100 * time.Millisecond {
+// 		return cachedLastCall
+// 	}
+// 	c.callTheShitAndCache()
+// 	return
+// }

--- a/util.go
+++ b/util.go
@@ -15,14 +15,11 @@
 package bstream
 
 import (
-	"context"
 	"encoding/binary"
 	"encoding/hex"
 	"fmt"
-	"time"
 
 	pbbstream "github.com/dfuse-io/pbgo/dfuse/bstream/v1"
-	"go.uber.org/zap"
 )
 
 // DoForProtocol extra the worker (a lambda) that will be invoked based on the
@@ -58,84 +55,4 @@ func toBlockNum(blockID string) uint64 {
 		return 0
 	}
 	return binary.BigEndian.Uint64(bin)
-}
-
-// DumbStartBlockResolver will help you start x blocks before your target start block
-func DumbStartBlockResolver(precedingBlocks uint64) StartBlockResolverFunc {
-	return func(_ context.Context, targetBlockNum uint64) (uint64, string, error) {
-		if targetBlockNum <= precedingBlocks {
-			return 0, "", nil
-		}
-		return targetBlockNum - precedingBlocks, "", nil
-	}
-}
-
-// ParallelStartResolver will call multiple resolvers to get the fastest answer. It retries each resolver 'attempts' time before bailing out. If attempts<0, it will retry forever.
-func ParallelStartResolver(resolvers []StartBlockResolver, attempts int) StartBlockResolverFunc {
-	return func(ctx context.Context, targetStartBlockNum uint64) (uint64, string, error) {
-		childrenCtx, cancelChildren := context.WithCancel(ctx)
-		defer cancelChildren()
-
-		outChan := make(chan *resolveStartBlockResp)
-		for _, resolver := range resolvers {
-			go attemptResolveStartBlock(childrenCtx, targetStartBlockNum, resolver, attempts, outChan)
-		}
-
-		var allErrors []error
-		for cnt := 0; cnt < len(resolvers); cnt++ {
-			select {
-			case <-ctx.Done():
-				return 0, "", ctx.Err()
-			case resp := <-outChan:
-				if resp.errs == nil {
-					return resp.startBlockNum, resp.previousIrreversibleID, nil
-				}
-				allErrors = append(allErrors, resp.errs...)
-			}
-		}
-
-		return 0, "", fmt.Errorf("errors during attempts to each resolver: %s", allErrors)
-	}
-}
-
-type resolveStartBlockResp struct {
-	startBlockNum          uint64
-	previousIrreversibleID string
-	errs                   []error
-}
-
-func attemptResolveStartBlock(ctx context.Context, targetStartBlockNum uint64, resolver StartBlockResolver, attempts int, outChan chan *resolveStartBlockResp) {
-	out := &resolveStartBlockResp{}
-	var errs []error
-
-	for attempt := 0; attempts < 0 || attempt <= attempts; attempt++ {
-		s, p, e := resolver.Resolve(ctx, targetStartBlockNum)
-		if e == nil {
-			zlog.Debug("resolved start block num", zap.Uint64("target_start_block_num", targetStartBlockNum), zap.Uint64("start_block_num", s), zap.String("previous_irreversible_id", p))
-			out.startBlockNum = s
-			out.previousIrreversibleID = p
-
-			select {
-			case outChan <- out:
-			case <-ctx.Done():
-			}
-			return
-		}
-
-		if ctx.Err() != nil {
-			return
-		}
-
-		zlog.Debug("got an error from a block resolver", zap.Error(e))
-		errs = append(errs, e)
-		attempt++
-		time.Sleep(time.Second)
-	}
-	out.errs = errs
-	select {
-	case outChan <- out:
-	case <-ctx.Done():
-	}
-	return
-
 }


### PR DESCRIPTION
* current implementation requires caller to give the blockstreamAddr to the joiningsource so it can lookup the current HEAD before connecting.

You can give two types of objects as LiveSource from within the the live SourceFactory at the moment:
1) a *blockstream.Source
2) a hub ? (or something)

There should be an interface to know if a source can give us a Getter
