### PR TITLE
add WithIrreversibilityChecker option to forkable, to truncate LIB

### DIFF
--- a/forkable/forkable.go
+++ b/forkable/forkable.go
@@ -255,7 +255,10 @@ func (p *Forkable) ProcessBlock(blk *bstream.Block, obj interface{}) error {
 	if p.irrChecker != nil {
 		p.irrChecker.CheckAsync(p.lastBlockSent, newLIBNum)
 		if newLIB := p.irrChecker.Found(); newLIB != nil {
-			libRef = newLIB
+			if newLIB.Num() > libRef.Num() && newLIB.Num() < newHeadBlock.Num() {
+				zlogBlk.Debug("moving LIB immediately because of the irrChecker", zap.Uint64("newlib_num", newLIB.Num()), zap.String("new_lib_id", newLIB.ID()))
+				libRef = newLIB
+			}
 		}
 	}
 

--- a/forkable/forkable.go
+++ b/forkable/forkable.go
@@ -44,15 +44,14 @@ type Forkable struct {
 }
 
 type irreversibilityChecker struct {
-	answer               chan bstream.BasicBlockRef
-	blockIDServer        pbblockmeta.BlockIDServer
-	delayBetweenChecks   time.Duration
-	maxNormalLIBDistance uint64
-	lastCheckTime        time.Time
+	answer             chan bstream.BasicBlockRef
+	blockIDServer      pbblockmeta.BlockIDServer
+	delayBetweenChecks time.Duration
+	lastCheckTime      time.Time
 }
 
 func (ic *irreversibilityChecker) CheckAsync(blk bstream.BlockRef, libNum uint64) {
-	if blk.Num() < libNum+ic.maxNormalLIBDistance { // only kick in when lib gets too far
+	if blk.Num() < libNum+bstream.GetMaxNormalLIBDistance { // only kick in when lib gets too far
 		return
 	}
 	if time.Since(ic.lastCheckTime) < ic.delayBetweenChecks {

--- a/forkable/forkable.go
+++ b/forkable/forkable.go
@@ -44,14 +44,15 @@ type Forkable struct {
 }
 
 type irreversibilityChecker struct {
-	answer             chan bstream.BasicBlockRef
-	blockIDServer      pbblockmeta.BlockIDServer
-	delayBetweenChecks time.Duration
-	lastCheckTime      time.Time
+	answer               chan bstream.BasicBlockRef
+	blockIDServer        pbblockmeta.BlockIDServer
+	delayBetweenChecks   time.Duration
+	maxNormalLIBDistance uint64
+	lastCheckTime        time.Time
 }
 
 func (ic *irreversibilityChecker) CheckAsync(blk bstream.BlockRef, libNum uint64) {
-	if blk.Num() < libNum+bstream.GetMaxNormalLIBDistance { // only kick in when lib gets too far
+	if blk.Num() < libNum+ic.maxNormalLIBDistance { // only kick in when lib gets too far
 		return
 	}
 	if time.Since(ic.lastCheckTime) < ic.delayBetweenChecks {

--- a/forkable/options.go
+++ b/forkable/options.go
@@ -43,13 +43,12 @@ func WithExclusiveLIB(irreversibleBlock bstream.BlockRef) Option {
 	}
 }
 
-func WithIrreversibilityChecker(blockIDServer pbblockmeta.BlockIDServer, delayBetweenChecks time.Duration, maxNormalLIBDistance uint64) Option {
+func WithIrreversibilityChecker(blockIDServer pbblockmeta.BlockIDServer, delayBetweenChecks time.Duration) Option {
 	return func(f *Forkable) {
 		f.irrChecker = &irreversibilityChecker{
-			blockIDServer:        blockIDServer,
-			delayBetweenChecks:   delayBetweenChecks,
-			maxNormalLIBDistance: maxNormalLIBDistance,
-			answer:               make(chan bstream.BasicBlockRef),
+			blockIDServer:      blockIDServer,
+			delayBetweenChecks: delayBetweenChecks,
+			answer:             make(chan bstream.BasicBlockRef),
 		}
 	}
 }

--- a/forkable/options.go
+++ b/forkable/options.go
@@ -43,12 +43,13 @@ func WithExclusiveLIB(irreversibleBlock bstream.BlockRef) Option {
 	}
 }
 
-func WithIrreversibilityChecker(blockIDServer pbblockmeta.BlockIDServer, delayBetweenChecks time.Duration) Option {
+func WithIrreversibilityChecker(blockIDServer pbblockmeta.BlockIDServer, delayBetweenChecks time.Duration, maxNormalLIBDistance uint64) Option {
 	return func(f *Forkable) {
 		f.irrChecker = &irreversibilityChecker{
-			blockIDServer:      blockIDServer,
-			delayBetweenChecks: delayBetweenChecks,
-			answer:             make(chan bstream.BasicBlockRef),
+			blockIDServer:        blockIDServer,
+			delayBetweenChecks:   delayBetweenChecks,
+			maxNormalLIBDistance: maxNormalLIBDistance,
+			answer:               make(chan bstream.BasicBlockRef),
 		}
 	}
 }

--- a/forkable/options.go
+++ b/forkable/options.go
@@ -15,7 +15,10 @@
 package forkable
 
 import (
+	"time"
+
 	"github.com/dfuse-io/bstream"
+	pbblockmeta "github.com/dfuse-io/pbgo/dfuse/blockmeta/v1"
 	"go.uber.org/zap"
 )
 
@@ -37,6 +40,16 @@ func WithInclusiveLIB(irreversibleBlock bstream.BlockRef) Option {
 func WithExclusiveLIB(irreversibleBlock bstream.BlockRef) Option {
 	return func(f *Forkable) {
 		f.forkDB.InitLIB(irreversibleBlock)
+	}
+}
+
+func WithIrreversibilityChecker(blockIDServer pbblockmeta.BlockIDServer, delayBetweenChecks time.Duration) Option {
+	return func(f *Forkable) {
+		f.irrChecker = &irreversibilityChecker{
+			blockIDServer:      blockIDServer,
+			delayBetweenChecks: delayBetweenChecks,
+			answer:             make(chan bstream.BasicBlockRef),
+		}
 	}
 }
 

--- a/registry.go
+++ b/registry.go
@@ -10,6 +10,7 @@ var GetBlockDecoder BlockDecoder
 var GetBlockWriterHeaderLen int
 var GetProtocolFirstStreamableBlock = uint64(0)
 var GetProtocolGenesisBlock = uint64(0)
+var GetMaxNormalLIBDistance = uint64(1000)
 
 func ValidateRegistry() error {
 	if GetBlockReaderFactory == nil {


### PR DESCRIPTION
This options allows giving the forkable a BlockIDServer (ex: GRPC connection to `blockmeta`).
When the distance between Head and LIB gets longer than bstream.GetMaxNormalLIBDistance (configurable per-chain), the forkable will, on every block if the `delayBetweenChecks` is passed, ask the blockIDServer to to confirm if current block ID is irreversible. If we are reprocessing old data, the blockIDServer might know something that we don't. If it gives us our head block as an irreversible block, we can move our lib immediately! (we look into the *future*)