### PR TITLE
retry when block reader from filesource gets an early EOF

### DIFF
--- a/filesource.go
+++ b/filesource.go
@@ -216,45 +216,50 @@ func (s *FileSource) runMergeFile() error {
 	}
 }
 
-func (s *FileSource) streamIncomingFile(newIncomingFile *incomingBlocksFile, blocksStore dstore.Store) error {
-	defer func() {
-		close(newIncomingFile.blocks)
-	}()
+type retryableError struct {
+	error
+}
 
-	atomic.AddInt64(&currentOpenFiles, 1)
-	s.logger.Debug("open files", zap.Int64("count", atomic.LoadInt64(&currentOpenFiles)), zap.String("filename", newIncomingFile.filename))
-	defer atomic.AddInt64(&currentOpenFiles, -1)
-
-	// FIXME: Eventually, RETRY for this given file.. and continue to write to `newIncomingFile`.
-	reader, err := blocksStore.OpenObject(context.Background(), newIncomingFile.filename)
-	if err != nil {
-		return fmt.Errorf("fetching %s from block store: %w", newIncomingFile.filename, err)
+func (e retryableError) Error() string {
+	return e.error.Error()
+}
+func retryable(err error) error {
+	return retryableError{
+		error: err,
 	}
-	defer reader.Close()
+}
+func isRetryable(err error) bool {
+	_, ok := err.(retryableError)
+	return ok
+}
 
-	blockReader, err := s.blockReaderFactory.New(reader)
-	if err != nil {
-		return fmt.Errorf("unable to create block reader: %w", err)
-	}
-
+func (s *FileSource) streamReader(blockReader BlockReader, prevLastBlockRead BlockRef, output chan *PreprocessedBlock) (lastBlockRead BlockRef, err error) {
+	prevPassed := prevLastBlockRead == nil
 	for {
 		if s.IsTerminating() {
-			s.logger.Info("shutting down incoming batch file download", zap.String("filename", newIncomingFile.filename))
-			return nil
+			return
 		}
 
-		blk, err := blockReader.Read()
+		var blk *Block
+		blk, err = blockReader.Read()
 		if err != nil && err != io.EOF {
-			return fmt.Errorf("block reader failed: %w", err)
+			return lastBlockRead, retryable(err) // unexpected error
 		}
 
-		// EOF can happen with valid data, so let's skip if no block defined
 		if err == io.EOF && (blk == nil || blk.Num() == 0) {
-			return nil
+			return lastBlockRead, nil // EOF without data
 		}
 
 		blockNum := blk.Num()
 		if blockNum < s.startBlockNum {
+			continue
+		}
+
+		if !prevPassed {
+			s.logger.Debug("skipping becaused !prevPassed", zap.Stringer("block", blk))
+			if prevLastBlockRead.ID() == blk.ID() {
+				prevPassed = true
+			}
 			continue
 		}
 
@@ -267,14 +272,54 @@ func (s *FileSource) streamIncomingFile(newIncomingFile *incomingBlocksFile, blo
 		if s.preprocFunc != nil {
 			obj, err = s.preprocFunc(blk)
 			if err != nil {
-				return fmt.Errorf("pre-process block failed: %w", err)
+				return lastBlockRead, fmt.Errorf("pre-process block failed: %w", err)
 			}
 		}
 
-		newIncomingFile.blocks <- &PreprocessedBlock{Block: blk, Obj: obj}
+		output <- &PreprocessedBlock{Block: blk, Obj: obj}
 		if err == io.EOF {
+			return lastBlockRead, nil
+		}
+	}
+}
+
+func (s *FileSource) streamIncomingFile(newIncomingFile *incomingBlocksFile, blocksStore dstore.Store) error {
+	defer func() {
+		close(newIncomingFile.blocks)
+	}()
+
+	atomic.AddInt64(&currentOpenFiles, 1)
+	s.logger.Debug("open files", zap.Int64("count", atomic.LoadInt64(&currentOpenFiles)), zap.String("filename", newIncomingFile.filename))
+	defer atomic.AddInt64(&currentOpenFiles, -1)
+
+	var lastBlockRead BlockRef
+	attempt := 0
+	for {
+		reader, err := blocksStore.OpenObject(context.Background(), newIncomingFile.filename)
+		if err != nil {
+			return fmt.Errorf("fetching %s from block store: %w", newIncomingFile.filename, err)
+		}
+
+		blockReader, err := s.blockReaderFactory.New(reader)
+		if err != nil {
+			reader.Close()
+			return fmt.Errorf("unable to create block reader: %w", err)
+		}
+
+		lastBlockRead, err = s.streamReader(blockReader, lastBlockRead, newIncomingFile.blocks)
+		reader.Close()
+
+		if err == nil {
 			return nil
 		}
+		if isRetryable(err) {
+			if attempt > 2 {
+				return fmt.Errorf("too many errors processing incoming file: %w", err)
+			}
+			attempt++
+			continue
+		}
+		return fmt.Errorf("non-retryable error processing incoming file: %w", err)
 	}
 }
 

--- a/filesource_test.go
+++ b/filesource_test.go
@@ -15,12 +15,21 @@
 package bstream
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/dfuse-io/dstore"
 	"github.com/stretchr/testify/require"
 )
+
+func TestRetryableError(t *testing.T) {
+	err := fmt.Errorf("hehe")
+	ret := retryableError{err}
+	require.True(t, isRetryable(ret))
+	require.False(t, isRetryable(err))
+	require.Equal(t, ret.Error(), err.Error())
+}
 
 func TestFileSource_Run(t *testing.T) {
 	bs := dstore.NewMockStore(nil)
@@ -47,7 +56,7 @@ func TestFileSource_Run(t *testing.T) {
 		return nil
 	})
 
-	fs := NewFileSource( bs, 1, 1, preprocessor, handler)
+	fs := NewFileSource(bs, 1, 1, preprocessor, handler)
 	go fs.Run()
 
 	select {


### PR DESCRIPTION
wrapped the processing, so we catch the error and start over from there.
Needs a quick review and test.