### PR TITLE
Rename IrrBlocksIndexProvider to BlockIndexManager, enable feeding from a BlockIndexProvider

### DIFF
--- a/block_index_manager.go
+++ b/block_index_manager.go
@@ -269,7 +269,6 @@ func (s *BlockIndexesManager) withinIndexRange(blockNum uint64) bool {
 	if blockNum <= s.irrIdxLoadedUpperBoundary {
 		return true
 	}
-	fmt.Println("CALLING LOAD RANGES UNTIL", blockNum, s.irrIdxLoadedUpperBoundary)
 	s.loadRangesUntil(blockNum)
 	return blockNum <= s.irrIdxLoadedUpperBoundary
 }

--- a/block_index_manager_test.go
+++ b/block_index_manager_test.go
@@ -192,7 +192,7 @@ func TestNewIrreversibleBlocksIndex(t *testing.T) {
 
 			irrStore, bundleSizes := getIrrStore(c.irreversibleBlocksIndexes)
 
-			bi := NewIrreversibleBlocksIndex(irrStore, bundleSizes, c.startBlockNum, c.cursorBlockRef)
+			bi := NewBlockIndexesManager(irrStore, bundleSizes, c.startBlockNum, c.cursorBlockRef, nil)
 
 			if c.expectNil {
 				require.Nil(t, bi)
@@ -204,7 +204,7 @@ func TestNewIrreversibleBlocksIndex(t *testing.T) {
 				nextBlockIDs = append(nextBlockIDs, br.BlockID)
 			}
 			assert.Equal(t, c.expectNextBlockIDs, nextBlockIDs)
-			assert.Equal(t, c.expectLoadedUpper, bi.loadedUpperBoundary)
+			assert.Equal(t, c.expectLoadedUpper, bi.irrIdxLoadedUpperBoundary)
 
 		})
 	}
@@ -259,9 +259,9 @@ func TestIrreversibleBlocksIndexNextMergedBlocksBase(t *testing.T) {
 	for _, c := range tests {
 		t.Run(c.name, func(t *testing.T) {
 
-			bi := &IrrBlocksIndexProvider{
+			bi := &BlockIndexesManager{
 				nextBlockRefs:                c.nextBlockRefs,
-				loadedUpperBoundary:          c.loadedUpperBoundary,
+				irrIdxLoadedUpperBoundary:    c.loadedUpperBoundary,
 				loadedUpperIrreversibleBlock: c.loadedUpperIrreversibleBlock,
 			}
 
@@ -439,19 +439,19 @@ func TestIrreversibleBlocksLoadRangesUntil(t *testing.T) {
 
 			irrStore, bundleSizes := getIrrStore(c.irreversibleBlocksIndexes)
 
-			bi := &IrrBlocksIndexProvider{
-				noMoreIndexes:       c.noMoreIndexes,
-				loadedUpperBoundary: c.loadedUpperBoundary,
-				nextBlockRefs:       c.nextBlockRefs,
-				store:               irrStore,
-				bundleSizes:         bundleSizes,
+			bi := &BlockIndexesManager{
+				noMoreIrrIdx:              c.noMoreIndexes,
+				irrIdxLoadedUpperBoundary: c.loadedUpperBoundary,
+				nextBlockRefs:             c.nextBlockRefs,
+				irrIdxStore:               irrStore,
+				irrIdxPossibleSizes:       bundleSizes,
 			}
 
 			bi.loadRangesUntil(c.untilWhat)
 
-			assert.EqualValues(t, c.expected.loadedUpperBoundary, bi.loadedUpperBoundary)
+			assert.EqualValues(t, c.expected.loadedUpperBoundary, bi.irrIdxLoadedUpperBoundary)
 			assert.Equal(t, c.expected.nextBlockRefs, bi.nextBlockRefs)
-			assert.Equal(t, c.expected.noMoreIndexes, bi.noMoreIndexes)
+			assert.Equal(t, c.expected.noMoreIndexes, bi.noMoreIrrIdx)
 
 		})
 	}
@@ -521,12 +521,12 @@ func TestIrreversibleBlocksSkip(t *testing.T) {
 
 			irrStore, bundleSizes := getIrrStore(c.irreversibleBlocksIndexes)
 
-			bi := &IrrBlocksIndexProvider{
+			bi := &BlockIndexesManager{
 				//noMoreIndexes:       c.noMoreIndexes,
-				loadedUpperBoundary: c.loadedUpperBoundary,
-				nextBlockRefs:       c.nextBlockRefs,
-				store:               irrStore,
-				bundleSizes:         bundleSizes,
+				irrIdxLoadedUpperBoundary: c.loadedUpperBoundary,
+				nextBlockRefs:             c.nextBlockRefs,
+				irrIdxStore:               irrStore,
+				irrIdxPossibleSizes:       bundleSizes,
 			}
 
 			seenSkip := bi.Skip(c.skipWhat)
@@ -628,8 +628,8 @@ func TestIrreversibleBlocksReorder(t *testing.T) {
 	for _, c := range tests {
 		t.Run(c.name, func(t *testing.T) {
 
-			bi := &IrrBlocksIndexProvider{
-				loadedUpperBoundary:       c.loadedUpperBoundary,
+			bi := &BlockIndexesManager{
+				irrIdxLoadedUpperBoundary: c.loadedUpperBoundary,
 				nextBlockRefs:             c.nextBlockRefs,
 				pendingPreprocessedBlocks: c.pendingPreprocessedBlocks,
 			}

--- a/firehose/firehose.go
+++ b/firehose/firehose.go
@@ -102,9 +102,11 @@ func (f *Firehose) createSource(ctx context.Context) (bstream.Source, error) {
 			}
 			irreversibleStartBlockNum = f.cursor.LIB.Num()
 		}
+		var indexProvider bstream.BlockIndexProvider
+		// TODO extract this from transforms
 
 		if !forkedCursor {
-			if irrIndex := bstream.NewIrreversibleBlocksIndex(f.irreversibleBlocksIndexStore, f.irreversibleBlocksIndexBundles, irreversibleStartBlockNum, cursorBlock); irrIndex != nil {
+			if irrIndex := bstream.NewBlockIndexesManager(f.irreversibleBlocksIndexStore, f.irreversibleBlocksIndexBundles, irreversibleStartBlockNum, cursorBlock, indexProvider); irrIndex != nil {
 				return bstream.NewIndexedFileSource(
 					f.wrappedHandler(false),
 					f.preprocessFunc,

--- a/firehose/firehose.go
+++ b/firehose/firehose.go
@@ -21,8 +21,9 @@ type Firehose struct {
 	irreversibleBlocksIndexWritable bool
 	irreversibleBlocksIndexBundles  []uint64
 
-	handler        bstream.Handler
-	preprocessFunc bstream.PreprocessFunc
+	handler            bstream.Handler
+	preprocessFunc     bstream.PreprocessFunc
+	blockIndexProvider bstream.BlockIndexProvider
 
 	cursor    *bstream.Cursor
 	forkSteps bstream.StepType
@@ -102,11 +103,9 @@ func (f *Firehose) createSource(ctx context.Context) (bstream.Source, error) {
 			}
 			irreversibleStartBlockNum = f.cursor.LIB.Num()
 		}
-		var indexProvider bstream.BlockIndexProvider
-		// TODO extract this from transforms
 
 		if !forkedCursor {
-			if irrIndex := bstream.NewBlockIndexesManager(f.irreversibleBlocksIndexStore, f.irreversibleBlocksIndexBundles, irreversibleStartBlockNum, cursorBlock, indexProvider); irrIndex != nil {
+			if irrIndex := bstream.NewBlockIndexesManager(f.irreversibleBlocksIndexStore, f.irreversibleBlocksIndexBundles, irreversibleStartBlockNum, cursorBlock, f.blockIndexProvider); irrIndex != nil {
 				return bstream.NewIndexedFileSource(
 					f.wrappedHandler(false),
 					f.preprocessFunc,

--- a/firehose/options.go
+++ b/firehose/options.go
@@ -40,7 +40,7 @@ func WithForkableSteps(steps bstream.StepType) Option {
 	}
 }
 
-func WithIndexProvider(p bstream.BlockIndexProvider) Option {
+func WithBlockIndexProvider(p bstream.BlockIndexProvider) Option {
 	return func(f *Firehose) {
 		f.blockIndexProvider = p
 	}

--- a/firehose/options.go
+++ b/firehose/options.go
@@ -40,6 +40,12 @@ func WithForkableSteps(steps bstream.StepType) Option {
 	}
 }
 
+func WithIndexProvider(p bstream.BlockIndexProvider) Option {
+	return func(f *Firehose) {
+		f.blockIndexProvider = p
+	}
+}
+
 func WithCursor(cursor *bstream.Cursor) Option {
 	return func(f *Firehose) {
 		f.cursor = cursor

--- a/indexed_filesource.go
+++ b/indexed_filesource.go
@@ -26,7 +26,7 @@ import (
 func NewIndexedFileSource(
 	handler Handler,
 	preprocFunc PreprocessFunc,
-	blockIndex BlockIndexProvider,
+	index *IrrBlocksIndexProvider,
 	blockStores []dstore.Store,
 	unindexedSourceFactory SourceFromNumFactory,
 	unindexedHandlerFactory func(h Handler, lib BlockRef) Handler,
@@ -43,7 +43,7 @@ func NewIndexedFileSource(
 		cursor:                  cursor,
 		handler:                 handler,
 		preprocFunc:             preprocFunc,
-		blockIndex:              blockIndex,
+		blockIndex:              index,
 		blockStores:             blockStores,
 		sendNew:                 sendNew,
 		sendIrr:                 sendIrr,
@@ -61,7 +61,7 @@ type IndexedFileSource struct {
 	lastProcessed BlockRef
 	cursor        *Cursor
 
-	blockIndex  BlockIndexProvider
+	blockIndex  *IrrBlocksIndexProvider
 	blockStores []dstore.Store
 	sendNew     bool
 	sendIrr     bool

--- a/indexed_filesource_test.go
+++ b/indexed_filesource_test.go
@@ -46,7 +46,7 @@ func TestFileSource_WrapObjectWithCursor(t *testing.T) {
 
 }
 
-func TestFileSource_IrrIndex(t *testing.T) {
+func TestFileSource_BlockIndexesManager_IrrOnly(t *testing.T) {
 	type expected struct {
 		blockIDs       []string
 		blockSteps     []StepType
@@ -364,7 +364,7 @@ func TestFileSource_IrrIndex(t *testing.T) {
 				Shutter:                 shutter.New(),
 				logger:                  zlog,
 				handler:                 handler,
-				blockIndex:              NewIrreversibleBlocksIndex(irrStore, bundleSizes, startBlockNum, mustMatch),
+				blockIndexManager:       NewBlockIndexesManager(irrStore, bundleSizes, startBlockNum, mustMatch, nil),
 				blockStores:             []dstore.Store{bs},
 				unindexedSourceFactory:  nextSourceFactory,
 				unindexedHandlerFactory: nextHandlerWrapper,
@@ -393,4 +393,325 @@ func TestFileSource_IrrIndex(t *testing.T) {
 		})
 	}
 
+}
+
+func TestFileSource_BlockIndexesManager_WithExtraIndexProvider(t *testing.T) {
+
+	type blockIDStep struct {
+		blockID    string
+		blockSteps StepType
+	}
+	type expected struct {
+		blocks         []blockIDStep
+		nextHandlerLIB BlockRef
+	}
+
+	tests := []struct {
+		name                      string
+		files                     map[int][]byte
+		irreversibleBlocksIndexes map[int]map[int]map[int]string
+		blockIndexProvider        BlockIndexProvider
+		expected                  expected
+	}{
+		{
+			name: "skip forked and non-matching blocks, nextHandlerLIB non-matching",
+			files: map[int][]byte{0: testBlocks(
+				4, "4a", "3a", 0,
+				6, "6a", "4a", 0,
+				6, "6b", "4a", 0,
+				8, "8a", "6a", 0,
+				99, "99a", "8a", 0,
+			),
+			},
+			irreversibleBlocksIndexes: map[int]map[int]map[int]string{
+				100: {
+					0: {
+						4: "4a",
+						6: "6a",
+						8: "8a",
+					},
+				},
+			},
+			blockIndexProvider: &mockBlockIndexProvider{
+				withinRange: map[uint64]bool{4: true},
+				matches: map[uint64]matchesResp{
+					4: {true, nil},
+				},
+				nextMatching: map[uint64]nextMatchingResp{
+					4: {6, false, nil},
+					6: {100, true, nil},
+					8: {100, true, nil},
+				},
+			},
+			expected: expected{
+				blocks: []blockIDStep{
+					{"4a", StepNew},
+					{"4a", StepIrreversible},
+					{"6a", StepNew},
+					{"6a", StepIrreversible},
+				},
+				nextHandlerLIB: BasicBlockRef{"8a", 8},
+			},
+		},
+		{
+			name: "empty index provider transition to irreversible index only",
+			files: map[int][]byte{0: testBlocks(
+				4, "4a", "3a", 0,
+				6, "6a", "4a", 0,
+				8, "8a", "6a", 0,
+			),
+				100: testBlocks(
+					100, "100a", "8a", 0,
+				),
+			},
+			irreversibleBlocksIndexes: map[int]map[int]map[int]string{
+				100: {
+					0: {
+						4: "4a",
+						6: "6a",
+						8: "8a",
+					},
+					100: {
+						100: "100a",
+					},
+				},
+			},
+			blockIndexProvider: &mockBlockIndexProvider{
+				withinRange: map[uint64]bool{
+					4:   true,
+					100: true,
+				},
+				matches: map[uint64]matchesResp{
+					4:   {false, nil},
+					100: {false, nil},
+				},
+				nextMatching: map[uint64]nextMatchingResp{
+					4:   {100, true, nil},
+					6:   {100, true, nil},
+					8:   {100, true, nil},
+					100: {100, true, nil},
+				},
+			},
+			expected: expected{
+				blocks: []blockIDStep{
+					{"100a", StepNew},
+					{"100a", StepIrreversible},
+				},
+				nextHandlerLIB: BasicBlockRef{"100a", 100},
+			},
+		},
+		{
+			name: "empty index provider transition to unindexed",
+			files: map[int][]byte{0: testBlocks(
+				4, "4a", "3a", 0,
+				6, "6a", "4a", 0,
+			),
+				100: testBlocks(
+					100, "100a", "6a", 0,
+				),
+			},
+			irreversibleBlocksIndexes: map[int]map[int]map[int]string{
+				100: {
+					0: {
+						4: "4a",
+						6: "6a",
+					},
+				},
+			},
+			blockIndexProvider: &mockBlockIndexProvider{
+				withinRange: map[uint64]bool{
+					4:   true,
+					100: true,
+				},
+				matches: map[uint64]matchesResp{
+					4:   {false, nil},
+					100: {false, nil},
+				},
+				nextMatching: map[uint64]nextMatchingResp{
+					4:   {100, true, nil},
+					6:   {100, true, nil},
+					100: {100, true, nil},
+				},
+			},
+			expected: expected{
+				blocks: []blockIDStep{
+					{"100a", StepNew},
+				},
+				nextHandlerLIB: BasicBlockRef{"6a", 6},
+			},
+		},
+		{
+			name: "non-empty index provider transition to irr only",
+			files: map[int][]byte{
+				0: testBlocks(
+					4, "4a", "3a", 0,
+					6, "6a", "4a", 0,
+				),
+				100: testBlocks(
+					100, "100a", "6a", 0,
+				),
+			},
+			irreversibleBlocksIndexes: map[int]map[int]map[int]string{
+				100: {
+					0: {
+						4: "4a",
+						6: "6a",
+					},
+					100: {
+						100: "100a",
+					},
+				},
+			},
+			blockIndexProvider: &mockBlockIndexProvider{
+				withinRange: map[uint64]bool{
+					4:   true,
+					6:   true,
+					100: true,
+				},
+				matches: map[uint64]matchesResp{
+					4:   {true, nil},
+					6:   {true, nil},
+					100: {false, nil},
+				},
+				nextMatching: map[uint64]nextMatchingResp{
+					4:   {6, false, nil},
+					6:   {100, false, nil},
+					100: {100, true, nil},
+				},
+			},
+			expected: expected{
+				blocks: []blockIDStep{
+					{"4a", StepNew},
+					{"4a", StepIrreversible},
+					{"6a", StepNew},
+					{"6a", StepIrreversible},
+					{"100a", StepNew},
+					{"100a", StepIrreversible},
+				},
+				nextHandlerLIB: BasicBlockRef{"100a", 100},
+			},
+		},
+	}
+
+	for _, c := range tests {
+		t.Run(c.name, func(t *testing.T) {
+
+			bs := dstore.NewMockStore(nil)
+			for i, data := range c.files {
+				bs.SetFile(base(i), data)
+			}
+
+			irrStore, bundleSizes := getIrrStore(c.irreversibleBlocksIndexes)
+
+			expectedBlockCount := len(c.expected.blocks)
+			var receivedBlocks []blockIDStep
+
+			expectedBlocksDone := make(chan interface{})
+			handler := HandlerFunc(func(blk *Block, obj interface{}) error {
+				step := StepNew
+				if stepable, ok := obj.(Stepable); ok {
+					step = stepable.Step()
+				}
+
+				receivedBlocks = append(receivedBlocks, blockIDStep{blk.Id, step})
+				if len(receivedBlocks) == expectedBlockCount {
+					close(expectedBlocksDone)
+				}
+				return nil
+			})
+
+			startBlockNum := uint64(1)
+
+			preprocFunc := func(blk *Block) (interface{}, error) {
+				return nil, nil
+			}
+
+			nextSourceFactory := func(startBlock uint64, h Handler) Source {
+				fs := NewFileSource(bs, startBlock, 1, preprocFunc, h)
+				return fs
+			}
+
+			nextHandlerWrapperCalled := make(chan interface{})
+			var receivedNextHandlerLIB BlockRef
+			nextHandlerWrapper := func(in Handler, lib BlockRef) Handler {
+				receivedNextHandlerLIB = lib
+				close(nextHandlerWrapperCalled)
+				return in
+			}
+
+			if c.blockIndexProvider != nil {
+				c.blockIndexProvider.(*mockBlockIndexProvider).t = t
+			}
+			ifs := &IndexedFileSource{
+				Shutter:                 shutter.New(),
+				logger:                  zlog,
+				handler:                 handler,
+				blockIndexManager:       NewBlockIndexesManager(irrStore, bundleSizes, startBlockNum, nil, c.blockIndexProvider),
+				blockStores:             []dstore.Store{bs},
+				unindexedSourceFactory:  nextSourceFactory,
+				unindexedHandlerFactory: nextHandlerWrapper,
+				preprocFunc:             preprocFunc,
+				sendNew:                 true,
+				sendIrr:                 true,
+			}
+			go ifs.Run()
+
+			select {
+			case <-expectedBlocksDone:
+			case <-time.After(100 * time.Millisecond):
+				t.Error(fmt.Sprintf("Test timeout waiting for %d blocks", expectedBlockCount))
+			}
+			select {
+			case <-nextHandlerWrapperCalled:
+			case <-time.After(100 * time.Millisecond):
+				t.Error("Test timeout waiting for nextHandlerWrapper to be called")
+			}
+
+			assert.EqualValues(t, c.expected.blocks, receivedBlocks)
+			assert.Equal(t, c.expected.nextHandlerLIB, receivedNextHandlerLIB)
+
+		})
+	}
+
+}
+
+type nextMatchingResp struct {
+	u uint64
+	b bool
+	e error
+}
+
+type matchesResp struct {
+	b bool
+	e error
+}
+
+type mockBlockIndexProvider struct {
+	t            *testing.T
+	withinRange  map[uint64]bool
+	matches      map[uint64]matchesResp
+	nextMatching map[uint64]nextMatchingResp
+}
+
+func (p *mockBlockIndexProvider) WithinRange(blockNum uint64) bool {
+	out, ok := p.withinRange[blockNum]
+	if !ok {
+		p.t.Errorf("withinRange value not set for %d", blockNum)
+	}
+	return out
+}
+
+func (p *mockBlockIndexProvider) Matches(blockNum uint64) (bool, error) {
+	out, ok := p.matches[blockNum]
+	if !ok {
+		p.t.Errorf("matches value not set for %d", blockNum)
+	}
+	return out.b, out.e
+}
+func (p *mockBlockIndexProvider) NextMatching(blockNum uint64) (num uint64, outsideIndexBoundary bool, err error) {
+	out, ok := p.nextMatching[blockNum]
+	if !ok {
+		p.t.Errorf("nextMatching value not set for %d", blockNum)
+	}
+	return out.u, out.b, out.e
 }

--- a/indexed_filesource_test.go
+++ b/indexed_filesource_test.go
@@ -438,9 +438,8 @@ func TestFileSource_BlockIndexesManager_WithExtraIndexProvider(t *testing.T) {
 					4: {true, nil},
 				},
 				nextMatching: map[uint64]nextMatchingResp{
-					4:  {6, false, nil},
-					6:  {100, true, nil},
-					99: {100, true, nil},
+					4: {6, false, nil},
+					6: {100, true, nil},
 				},
 			},
 			expected: expected{
@@ -487,8 +486,6 @@ func TestFileSource_BlockIndexesManager_WithExtraIndexProvider(t *testing.T) {
 				},
 				nextMatching: map[uint64]nextMatchingResp{
 					4:   {100, true, nil},
-					6:   {100, true, nil},
-					8:   {100, true, nil},
 					100: {100, true, nil},
 				},
 			},
@@ -528,9 +525,7 @@ func TestFileSource_BlockIndexesManager_WithExtraIndexProvider(t *testing.T) {
 					100: {false, nil},
 				},
 				nextMatching: map[uint64]nextMatchingResp{
-					4:   {100, true, nil},
-					6:   {100, true, nil},
-					100: {100, true, nil},
+					4: {100, true, nil},
 				},
 			},
 			expected: expected{

--- a/indexed_filesource_test.go
+++ b/indexed_filesource_test.go
@@ -419,28 +419,28 @@ func TestFileSource_BlockIndexesManager_WithExtraIndexProvider(t *testing.T) {
 				4, "4a", "3a", 0,
 				6, "6a", "4a", 0,
 				6, "6b", "4a", 0,
-				8, "8a", "6a", 0,
-				99, "99a", "8a", 0,
+				8, "8b", "6a", 0,
+				99, "99a", "6a", 0,
 			),
 			},
 			irreversibleBlocksIndexes: map[int]map[int]map[int]string{
 				100: {
 					0: {
-						4: "4a",
-						6: "6a",
-						8: "8a",
+						4:  "4a",
+						6:  "6a",
+						99: "99a",
 					},
 				},
 			},
-			blockIndexProvider: &mockBlockIndexProvider{
+			blockIndexProvider: &mockBlockIndexProvider{ // matches 4 and 6 only
 				withinRange: map[uint64]bool{4: true},
 				matches: map[uint64]matchesResp{
 					4: {true, nil},
 				},
 				nextMatching: map[uint64]nextMatchingResp{
-					4: {6, false, nil},
-					6: {100, true, nil},
-					8: {100, true, nil},
+					4:  {6, false, nil},
+					6:  {100, true, nil},
+					99: {100, true, nil},
 				},
 			},
 			expected: expected{
@@ -450,7 +450,7 @@ func TestFileSource_BlockIndexesManager_WithExtraIndexProvider(t *testing.T) {
 					{"6a", StepNew},
 					{"6a", StepIrreversible},
 				},
-				nextHandlerLIB: BasicBlockRef{"8a", 8},
+				nextHandlerLIB: BasicBlockRef{"99a", 99}, // ready for forkable to start at block 100 with LIB=99a
 			},
 		},
 		{

--- a/interfaces.go
+++ b/interfaces.go
@@ -55,3 +55,9 @@ type SourceFactory func(h Handler) Source
 type SourceFromRefFactory func(startBlockRef BlockRef, h Handler) Source
 type SourceFromNumFactory func(startBlockNum uint64, h Handler) Source
 type SourceFromNumFactoryWithErr func(startBlockNum uint64, h Handler) (Source, error)
+
+type IndexProvider interface {
+	WithinRange(blockNum uint64) bool
+	Matches(blockNum uint64) (bool, error)
+	NextMatching(blockNum uint64) (num uint64, outsideIndexBoundary bool, err error) // when outsideIndexBoundary is true, the returned blocknum is the first Unindexed block
+}

--- a/interfaces.go
+++ b/interfaces.go
@@ -56,6 +56,10 @@ type SourceFromRefFactory func(startBlockRef BlockRef, h Handler) Source
 type SourceFromNumFactory func(startBlockNum uint64, h Handler) Source
 type SourceFromNumFactoryWithErr func(startBlockNum uint64, h Handler) (Source, error)
 
+type BlockIndexProviderGetter interface {
+	GetIndexProvider() BlockIndexProvider
+}
+
 type BlockIndexProvider interface {
 	WithinRange(blockNum uint64) bool
 	Matches(blockNum uint64) (bool, error)

--- a/interfaces.go
+++ b/interfaces.go
@@ -56,7 +56,7 @@ type SourceFromRefFactory func(startBlockRef BlockRef, h Handler) Source
 type SourceFromNumFactory func(startBlockNum uint64, h Handler) Source
 type SourceFromNumFactoryWithErr func(startBlockNum uint64, h Handler) (Source, error)
 
-type IndexProvider interface {
+type BlockIndexProvider interface {
 	WithinRange(blockNum uint64) bool
 	Matches(blockNum uint64) (bool, error)
 	NextMatching(blockNum uint64) (num uint64, outsideIndexBoundary bool, err error) // when outsideIndexBoundary is true, the returned blocknum is the first Unindexed block

--- a/transform/interfaces.go
+++ b/transform/interfaces.go
@@ -16,18 +16,6 @@ type Input interface {
 
 type Output proto.Message
 
-//type BlockTransformer interface {
-//	// ALWAYS PARALLELIZABLE BY DEFINITION. It is CONTEXT FREE with regards to other blocks around him.
-//
-//	// ModifiesBlock bool
-//	// IsDeterministic bool
-//}
-//
-//type BlockRangeTransformer interface {
-//	CanSkipRange(start, end uint64) (bool, error)
-//	NextUnsparse(block uint64) uint64
-//}
-
 const (
 	NilObjectType string = "nil"
 )


### PR DESCRIPTION
* allows chain-specific indexes to be added to the BlockIndexManager
* they need to implement BlockIndexProvider interface
