### PR TITLE
fix forkable/cursor issues: remove Genesis

### DIFF
--- a/cursor.go
+++ b/cursor.go
@@ -109,14 +109,6 @@ func (c *Cursor) IsEmpty() bool {
 		c.LIB.ID() == ""
 }
 
-// StartBlockNum gives you the info on "where to start feeding blocks"
-func (c *Cursor) StartBlockNum() uint64 {
-	if c.IsEmpty() {
-		return 0
-	}
-	return c.LIB.Num()
-}
-
 func (c *Cursor) String() string {
 	blkID := c.Block.ID()
 	headID := c.HeadBlock.ID()

--- a/firehose/firehose.go
+++ b/firehose/firehose.go
@@ -271,6 +271,10 @@ func (f *Firehose) joiningSourceFactoryFromCursor(cursor *bstream.Cursor) bstrea
 
 		fileStartBlock := cursor.LIB.Num() // we don't use startBlockNum, the forkable will wait for the cursor before it forwards blocks
 		if fileStartBlock < bstream.GetProtocolFirstStreamableBlock {
+			f.logger.Info("adjusting requested file_start_block to protocol_first_streamable_block",
+				zap.Uint64("file_start_block", fileStartBlock),
+				zap.Uint64("protocol_first_streamable_block", bstream.GetProtocolFirstStreamableBlock),
+			)
 			fileStartBlock = bstream.GetProtocolFirstStreamableBlock
 		}
 		joiningSourceOptions = append(joiningSourceOptions, bstream.JoiningSourceTargetBlockID(cursor.LIB.ID()))

--- a/firehose/firehose.go
+++ b/firehose/firehose.go
@@ -262,6 +262,9 @@ func (f *Firehose) joiningSourceFactoryFromCursor(cursor *bstream.Cursor) bstrea
 		}
 
 		fileStartBlock := cursor.LIB.Num() // we don't use startBlockNum, the forkable will wait for the cursor before it forwards blocks
+		if fileStartBlock < bstream.GetProtocolFirstStreamableBlock {
+			fileStartBlock = bstream.GetProtocolFirstStreamableBlock
+		}
 		joiningSourceOptions = append(joiningSourceOptions, bstream.JoiningSourceTargetBlockID(cursor.LIB.ID()))
 
 		f.logger.Info("firehose pipeline bootstrapping from cursor",

--- a/forkable/forkable.go
+++ b/forkable/forkable.go
@@ -304,7 +304,11 @@ func (p *Forkable) feedCursorStateRestorer(blk *bstream.Block, obj interface{}) 
 				headBlock = fblk
 			}
 		}
-		libRef := p.forkDB.BlockInCurrentChain(headBlock.Block, headBlock.Block.LibNum)
+		upTo := headBlock.Block.LibNum
+		if upTo < bstream.GetProtocolFirstStreamableBlock {
+			upTo = bstream.GetProtocolFirstStreamableBlock
+		}
+		libRef := p.forkDB.BlockInCurrentChain(headBlock.Block, upTo)
 		hasNew, irreversibleSegment, _ := p.forkDB.HasNewIrreversibleSegment(libRef)
 		if hasNew {
 			_ = p.forkDB.MoveLIB(libRef)

--- a/forkable/forkable.go
+++ b/forkable/forkable.go
@@ -71,7 +71,7 @@ func RelativeLIBNumGetter(confirmations uint64) LIBNumGetter {
 		blknum := blk.Num()
 		switch {
 		case blknum <= bstream.GetProtocolFirstStreamableBlock:
-			return bstream.GetProtocolGenesisBlock
+			return bstream.GetProtocolFirstStreamableBlock
 		case blknum <= confirmations:
 			libNum = bstream.GetProtocolFirstStreamableBlock
 		default:
@@ -250,11 +250,9 @@ func (p *Forkable) feedCursorStateRestorer(blk *bstream.Block, obj interface{}) 
 
 	// FIXME: eventually check if all of those are linked in a full segment ?
 	cur := p.gateCursor
-	if !p.forkDB.Exists(cur.HeadBlock.ID()) ||
-		!p.forkDB.Exists(cur.Block.ID()) ||
-		!p.forkDB.Exists(cur.LIB.ID()) {
+	if !p.forkDB.Exists(cur.Block.ID()) || !p.forkDB.Exists(cur.HeadBlock.ID()) {
 		if traceEnabled {
-			zlog.Debug("missing at least one block", zap.Stringer("cursor", cur))
+			zlog.Debug("missing cursor block or head_block in forkDB", zap.Stringer("cursor", cur), zap.Stringer("block", cur.Block), zap.Stringer("head_block", cur.HeadBlock))
 		}
 		return
 	}
@@ -283,6 +281,11 @@ func (p *Forkable) feedCursorStateRestorer(blk *bstream.Block, obj interface{}) 
 				}
 			}
 		}
+		// special case for first cursor on first streamable block (sent as NEW, then sent as IRR)
+		if cur.Block.Num() == bstream.GetProtocolFirstStreamableBlock && cur.Step == bstream.StepNew {
+			return p.processInitialInclusiveIrreversibleBlock(blk, obj, false)
+		}
+
 		// we want the head block to 'come in as new'
 		if cur.HeadBlock.ID() != cur.Block.ID() {
 			p.forkDB.DeleteLink(cur.HeadBlock.ID())
@@ -336,22 +339,11 @@ func (p *Forkable) ProcessBlock(blk *bstream.Block, obj interface{}) error {
 		zlogBlk.Debug("processing block (1/600 sampling)", zap.Bool("new_longest_chain", triggersNewLongestChain))
 	}
 
-	ppBlk := &ForkableBlock{Block: blk, Obj: obj}
-
 	if p.includeInitialLIB && p.lastBlockSent == nil && blk.ID() == p.forkDB.LIBID() {
-		return p.processInitialInclusiveIrreversibleBlock(blk, obj)
+		return p.processInitialInclusiveIrreversibleBlock(blk, obj, true)
 	}
-	// special case to send the LIB if we receive it on an initlib'ed empty forkdb. Easier in some contexts.
-	// ex: I have block 00000004a in my hands, and I know it is irreversible.
-	//     I initLIB with 00000003a, then I send the block 00000003a in, I want it pushed :D
-	// if p.lastBlockSent == nil && blk.ID() == p.forkDB.LIBID() {
-	// 	zlogBlk.Debug("sending block through, it is our lib", zap.String("blk_id", blk.ID()), zap.Uint64("blk_num", blk.Num()))
-	// 	return p.handler.ProcessBlock(blk, &ForkableObject{
-	// 		Step:   StepNew,
-	// 		ForkDB: p.forkDB,
-	// 		Obj:    obj,
-	// 	})
-	// }
+
+	ppBlk := &ForkableBlock{Block: blk, Obj: obj}
 
 	var undos, redos []*ForkableBlock
 	if p.matchFilter(bstream.StepUndo | bstream.StepRedo) {
@@ -363,10 +355,15 @@ func (p *Forkable) ProcessBlock(blk *bstream.Block, obj interface{}) error {
 	if exists := p.forkDB.AddLink(blk, blk.PreviousID(), ppBlk); exists {
 		return nil
 	}
+
 	var firstIrreverbleBlock *Block
 	if !p.forkDB.HasLIB() { // always skip processing until LIB is set
 		p.forkDB.TrySetLIB(blk, blk.PreviousID(), p.blockLIBNum(blk))
 		if p.forkDB.HasLIB() { //this is an edge case. forkdb will not is returning the 1st lib in the forkDB.HasNewIrreversibleSegment call
+			if p.forkDB.libRef.Num() == blk.Number { // this block just came in and was determined as LIB, it is probably first streamable block and must be processed.
+				return p.processInitialInclusiveIrreversibleBlock(blk, obj, true)
+			}
+
 			firstIrreverbleBlock = p.forkDB.BlockForID(p.forkDB.libRef.ID())
 		}
 	}
@@ -590,7 +587,7 @@ func (p *Forkable) processNewBlocks(longestChain []*Block) (err error) {
 	return
 }
 
-func (p *Forkable) processInitialInclusiveIrreversibleBlock(blk *bstream.Block, obj interface{}) error {
+func (p *Forkable) processInitialInclusiveIrreversibleBlock(blk *bstream.Block, obj interface{}, sendAsNew bool) error {
 	// Normally extracted from ForkDB, we create it here:
 	singleBlock := &Block{
 		BlockID:  blk.ID(),
@@ -605,8 +602,10 @@ func (p *Forkable) processInitialInclusiveIrreversibleBlock(blk *bstream.Block, 
 
 	tinyChain := []*Block{singleBlock}
 
-	if err := p.processNewBlocks(tinyChain); err != nil {
-		return err
+	if sendAsNew {
+		if err := p.processNewBlocks(tinyChain); err != nil {
+			return err
+		}
 	}
 
 	if err := p.processIrreversibleSegment(tinyChain, blk); err != nil {

--- a/forkable/forkdb.go
+++ b/forkable/forkdb.go
@@ -86,6 +86,7 @@ func (f *ForkDB) SetLogger(logger *zap.Logger) {
 func (f *ForkDB) TrySetLIB(headRef bstream.BlockRef, previousRefID string, libNum uint64) {
 	if headRef.Num() == bstream.GetProtocolFirstStreamableBlock {
 		f.libRef = headRef
+		f.logger.Debug("TrySetLIB received first streamable block of chain, assuming it's the new LIB", zap.Stringer("lib", f.libRef))
 		return
 	}
 	libRef := f.BlockInCurrentChain(headRef, libNum)
@@ -101,6 +102,7 @@ func (f *ForkDB) TrySetLIB(headRef bstream.BlockRef, previousRefID string, libNu
 func (f *ForkDB) SetLIB(headRef bstream.BlockRef, previousRefID string, libNum uint64) {
 	if headRef.Num() == bstream.GetProtocolFirstStreamableBlock {
 		f.libRef = headRef
+		f.logger.Debug("SetLIB received first streamable block of chain, assuming it's the new LIB", zap.Stringer("lib", f.libRef))
 		return
 	}
 	libRef := f.BlockInCurrentChain(headRef, libNum)

--- a/forkable/forkdb.go
+++ b/forkable/forkdb.go
@@ -225,6 +225,9 @@ func (f *ForkDB) AddLink(blockRef bstream.BlockRef, previousRefID string, obj in
 func (f *ForkDB) BlockInCurrentChain(startAtBlock bstream.BlockRef, blockNum uint64) bstream.BlockRef {
 	f.linksLock.Lock()
 	defer f.linksLock.Unlock()
+	if startAtBlock.Num() == blockNum {
+		return startAtBlock
+	}
 
 	cur := startAtBlock.ID()
 	for {

--- a/forkable/forkdb.go
+++ b/forkable/forkdb.go
@@ -85,10 +85,8 @@ func (f *ForkDB) SetLogger(logger *zap.Logger) {
 // unknown behaviour if it was already set ... maybe it explodes
 func (f *ForkDB) TrySetLIB(headRef bstream.BlockRef, previousRefID string, libNum uint64) {
 	if headRef.Num() == bstream.GetProtocolFirstStreamableBlock {
-		f.libRef = bstream.NewBlockRef(previousRefID, bstream.GetProtocolGenesisBlock)
-		libNum = bstream.GetProtocolGenesisBlock
-
-		f.logger.Debug("candidate LIB received is first streamable block of chain, assuming it's the new LIB", zap.Stringer("lib", f.libRef))
+		f.libRef = headRef
+		return
 	}
 	libRef := f.BlockInCurrentChain(headRef, libNum)
 	if libRef.ID() == "" {
@@ -102,10 +100,8 @@ func (f *ForkDB) TrySetLIB(headRef bstream.BlockRef, previousRefID string, libNu
 //Set a new lib without cleaning up blocks older then new lib (NO MOVE)
 func (f *ForkDB) SetLIB(headRef bstream.BlockRef, previousRefID string, libNum uint64) {
 	if headRef.Num() == bstream.GetProtocolFirstStreamableBlock {
-		f.libRef = bstream.NewBlockRef(previousRefID, bstream.GetProtocolGenesisBlock)
-		libNum = bstream.GetProtocolGenesisBlock
-
-		f.logger.Debug("candidate LIB received is first streamable block of chain, assuming it's the new LIB", zap.Stringer("lib", f.libRef))
+		f.libRef = headRef
+		return
 	}
 	libRef := f.BlockInCurrentChain(headRef, libNum)
 	if libRef.ID() == "" {
@@ -298,16 +294,16 @@ func (f *ForkDB) ReversibleSegment(startBlock bstream.BlockRef) (blocks []*Block
 				// This was Debug before but when serving Firehose request and there is a hole in one
 				// of the merged blocks, it means you see almost nothing since normal logging is at Info.
 				// This force usage of debug log to see something. Switched to be a warning since an unlinkable
-				// block is not something that should happen, specially between `upToBlock` and `LIB`, which is
+				// block is not something that should happen, specially between `startBlock` and `LIB`, which is
 				// the case here.
 				//
-				// If you come by to switch to Debug because it's too verbose, we should think about a way to
+				// If you came here to switch to Debug because it's too verbose, we should think about a way to
 				// reduce the occurrence, at least logging once at Warn/Info and the rest in Debug.
-				f.logger.Warn("forkdb unlinkable block, unable to reach LIB by following parent links",
+				f.logger.Warn("forkdb unlinkable block, unable to reach last irrerversible block by following parent links",
 					zap.Stringer("lib", f.libRef),
 					zap.Stringer("start_block", startBlock),
-					zap.Stringer("current_block", bstream.NewBlockRef(curID, curNum)),
-					zap.Stringer("missing_parent_of", bstream.NewBlockRef(prevID, prevNum)),
+					zap.String("missing_block_id", curID),
+					zap.Stringer("missing_parent_of_block", bstream.NewBlockRef(prevID, prevNum)),
 				)
 				return nil, false // when LIB is set we need to reach it
 			}

--- a/forkable/options.go
+++ b/forkable/options.go
@@ -30,6 +30,7 @@ func FromCursor(cursor *bstream.Cursor) Option {
 		if cursor.IsEmpty() {
 			return
 		}
+		f.forkDB.InitLIB(cursor.LIB)
 
 		// this should simply gate until we see those specific cursor values
 		f.gateCursor = cursor

--- a/indexed_filesource.go
+++ b/indexed_filesource.go
@@ -87,7 +87,7 @@ func (s *IndexedFileSource) SetLogger(l *zap.Logger) {
 
 func (s *IndexedFileSource) run() error {
 	if s.cursor != nil && s.cursor.Step != StepNew && s.cursor.Step != StepIrreversible {
-		return fmt.Errorf("error: invalid cursor on indexed file source, this should not happen")
+		return fmt.Errorf("invalid cursor on indexed file source, this should not happen")
 	}
 	for {
 		base, lib, hasIndex := s.blockIndex.NextMergedBlocksBase()

--- a/registry.go
+++ b/registry.go
@@ -9,7 +9,6 @@ var GetBlockWriterFactory BlockWriterFactory
 var GetBlockDecoder BlockDecoder
 var GetBlockWriterHeaderLen int
 var GetProtocolFirstStreamableBlock = uint64(0)
-var GetProtocolGenesisBlock = uint64(0)
 var GetMaxNormalLIBDistance = uint64(1000)
 
 func ValidateRegistry() error {

--- a/tracker.go
+++ b/tracker.go
@@ -202,6 +202,9 @@ func (t *Tracker) ResolveStartBlock(ctx context.Context, targetBlockNum uint64) 
 			errs = append(errs, err.Error())
 			continue
 		}
+		if startBlockNum < GetProtocolFirstStreamableBlock {
+			startBlockNum = GetProtocolFirstStreamableBlock
+		}
 		return
 	}
 	err = errors.New("resolving block reference: " + strings.Join(errs, ", "))


### PR DESCRIPTION
* remove the GetProtocolGenesisBlock global variable in bstream registry
* forkable: deterministically handle receiving the FirstStreamableBlock by setting its LIB to itself.
  (ex: block 1a entering uninitialized forkable will set the forkdb LIB to 1a, send NEW(1a), then IRREVERSIBLE(1a))
* reworked initialization of LIB from cursor (now it is put in forkdb right away, before we even see it)
* added special case for sending firstStreamableBlock as New, then Irreversible
* firehose no more startBlock resolved "before FirstStreamableBlock"
* no more confusing cursor.StartBlockNum() (was not used)
* adjusted tests
* IndexedFileSource was not honoring the cursor correctly around its start block, it now gets the cursor to skip corresponding StepNew or StepIrreversible.