### PR TITLE
major rework of index manager

### DIFF
--- a/block_index_manager.go
+++ b/block_index_manager.go
@@ -435,12 +435,14 @@ func (s *BlockIndexesManager) nextInterestingRange() uint64 {
 	next := s.irrIdxLoadedUpperBoundary + 1
 	if s.blockIndexProvider != nil {
 		num, endReached, err := s.blockIndexProvider.NextMatching(s.ctx, s.irrIdxLoadedUpperBoundary, s.stopBlockNum)
-		if endReached || err != nil {
+		if err != nil {
+			s.disableBlockIndexProvider()
+			return next
+		}
+		if endReached {
 			s.disableBlockIndexProvider()
 		}
-		if err == nil {
-			next = num
-		}
+		next = num
 	}
 	return next
 }

--- a/block_index_manager.go
+++ b/block_index_manager.go
@@ -432,17 +432,18 @@ func (s *BlockIndexesManager) loadRangesUntilMatch() {
 }
 
 func (s *BlockIndexesManager) nextInterestingRange() uint64 {
-	next := s.irrIdxLoadedUpperBoundary + 1
-	if s.blockIndexProvider != nil {
-		num, endReached, err := s.blockIndexProvider.NextMatching(s.ctx, s.irrIdxLoadedUpperBoundary, s.stopBlockNum)
-		if err != nil {
-			s.disableBlockIndexProvider()
-			return next
-		}
-		if endReached {
-			s.disableBlockIndexProvider()
-		}
-		next = num
+	defaultValue := s.irrIdxLoadedUpperBoundary + 1
+	if s.blockIndexProvider == nil {
+		return defaultValue
+	}
+
+	next, endReached, err := s.blockIndexProvider.NextMatching(s.ctx, s.irrIdxLoadedUpperBoundary, s.stopBlockNum)
+	if err != nil {
+		s.disableBlockIndexProvider()
+		return defaultValue
+	}
+	if endReached {
+		s.disableBlockIndexProvider()
 	}
 	return next
 }

--- a/firehose/firehose.go
+++ b/firehose/firehose.go
@@ -105,7 +105,7 @@ func (f *Firehose) createSource(ctx context.Context) (bstream.Source, error) {
 		}
 
 		if !forkedCursor {
-			if irrIndex := bstream.NewBlockIndexesManager(f.irreversibleBlocksIndexStore, f.irreversibleBlocksIndexBundles, irreversibleStartBlockNum, cursorBlock, f.blockIndexProvider); irrIndex != nil {
+			if irrIndex := bstream.NewBlockIndexesManager(ctx, f.irreversibleBlocksIndexStore, f.irreversibleBlocksIndexBundles, irreversibleStartBlockNum, f.stopBlockNum, cursorBlock, f.blockIndexProvider); irrIndex != nil {
 				return bstream.NewIndexedFileSource(
 					f.wrappedHandler(false),
 					f.preprocessFunc,

--- a/indexed_filesource.go
+++ b/indexed_filesource.go
@@ -151,7 +151,7 @@ func (s *IndexedFileSource) WrappedProcessBlock(blk *Block, obj interface{}) err
 		s.skipCount++
 		if s.skipCount%10 == 0 {
 			nextBase, _, hasIndex := s.blockIndexManager.NextMergedBlocksBase()
-			if hasIndex && safeMinus(blk.Number, nextBase) > 200 {
+			if hasIndex && safeMinus(nextBase, blk.Number) > 200 {
 				return SkipToNextRange
 			}
 		}

--- a/interfaces.go
+++ b/interfaces.go
@@ -15,6 +15,8 @@
 package bstream
 
 import (
+	"context"
+
 	"go.uber.org/zap"
 )
 
@@ -61,7 +63,18 @@ type BlockIndexProviderGetter interface {
 }
 
 type BlockIndexProvider interface {
-	WithinRange(blockNum uint64) bool
-	Matches(blockNum uint64) (bool, error)
-	NextMatching(blockNum uint64) (num uint64, outsideIndexBoundary bool, err error) // when outsideIndexBoundary is true, the returned blocknum is the first Unindexed block
+	// WithinRange informs you that this block number can be queried on the index
+	// Any error accessing the index will return false
+	WithinRange(ctx context.Context, blockNum uint64) bool
+
+	// Matches Returns true if that blockNum matches the index
+	// When an error is returned, you should assume that this block must go through
+	Matches(ctx context.Context, blockNum uint64) (bool, error)
+
+	// NextMatching tries to return the matches from the index.
+	// When there is a match under exclusiveUpTo, its number is returned, (num, false, nil)
+	// When the end of the index is reached, outsideIndexBoundary is true and the returned blocknum is the first Unindexed block (firstBlockPastIndex, true, nil)
+	// When there was an issue reading the index file, the error will be set
+	// When there are no matches until exclusiveUpTo, it will be returned (exclusiveUpTo, false, nil)
+	NextMatching(ctx context.Context, blockNum, exclusiveUpTo uint64) (num uint64, outsideIndexBoundary bool, err error)
 }


### PR DESCRIPTION
fix multiple issues with indexManager not optimizing cases that it should

* indexedFilesource's SkipToNextRange had a typo in calculation
* add stopBlockNum to blockIndexManager so it does not look for blocks beyond it
* add 'upTo' param to NextMatching() in blockIndexProvider interface
* add context to all calls on BlockIndexProvider interface
* add context to blockIndexManager so it cancels with requests
* add cursorBlock to blockIndexManager to ensure it always passes
* clarify BlockIndexManager new/initialization
* split loadRangesUntilMatch() behavior from loadRangeUntil(blockNum)