### PR TITLE
Feature/prefix index lookup

### DIFF
--- a/transform/block_index.go
+++ b/transform/block_index.go
@@ -2,6 +2,7 @@ package transform
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/RoaringBitmap/roaring/roaring64"
 	"github.com/golang/protobuf/proto"
@@ -32,6 +33,22 @@ func NewBlockIndex(lowBlockNum, indexSize uint64) *blockIndex {
 
 func (i *blockIndex) Get(key string) *roaring64.Bitmap {
 	return i.kv[key]
+}
+
+func (i *blockIndex) GetByPrefix(prefix string) *roaring64.Bitmap {
+	var matching []*roaring64.Bitmap
+	for k, v := range i.kv {
+		if strings.HasPrefix(k, prefix) {
+			matching = append(matching, v)
+		}
+	}
+	switch len(matching) {
+	case 0:
+		return nil
+	case 1:
+		return matching[0]
+	}
+	return roaring64.FastOr(matching...)
 }
 
 // marshal converts the current index to a protocol buffer

--- a/transform/block_index.go
+++ b/transform/block_index.go
@@ -51,6 +51,22 @@ func (i *blockIndex) GetByPrefix(prefix string) *roaring64.Bitmap {
 	return roaring64.FastOr(matching...)
 }
 
+func (i *blockIndex) GetBySuffix(suffix string) *roaring64.Bitmap {
+	var matching []*roaring64.Bitmap
+	for k, v := range i.kv {
+		if strings.HasSuffix(k, suffix) {
+			matching = append(matching, v)
+		}
+	}
+	switch len(matching) {
+	case 0:
+		return nil
+	case 1:
+		return matching[0]
+	}
+	return roaring64.FastOr(matching...)
+}
+
 // marshal converts the current index to a protocol buffer
 func (i *blockIndex) marshal() ([]byte, error) {
 	pbIndex := &pbbstream.GenericBlockIndex{}

--- a/transform/block_index_provider.go
+++ b/transform/block_index_provider.go
@@ -15,6 +15,7 @@ import (
 type BitmapGetter interface {
 	Get(string) *roaring64.Bitmap
 	GetByPrefix(string) *roaring64.Bitmap
+	GetBySuffix(string) *roaring64.Bitmap
 }
 
 // GenericBlockIndexProvider responds to queries on BlockIndex
@@ -49,7 +50,6 @@ func NewGenericBlockIndexProvider(
 	possibleIndexSizes []uint64,
 	filterFunc func(BitmapGetter) []uint64,
 ) *GenericBlockIndexProvider {
-
 	// @todo(froch, 20220223): firm up what the possibleIndexSizes can be
 	if possibleIndexSizes == nil {
 		possibleIndexSizes = []uint64{100000, 10000, 1000, 100}
@@ -129,7 +129,6 @@ func (ip *GenericBlockIndexProvider) NextMatching(ctx context.Context, blockNum 
 // findIndexContaining tries to find an index file in dstore containing the provided blockNum
 // if such a file exists, returns an io.Reader; nil otherwise
 func (ip *GenericBlockIndexProvider) findIndexContaining(ctx context.Context, blockNum uint64) (r io.ReadCloser, lowBlockNum, indexSize uint64) {
-
 	for _, size := range ip.possibleIndexSizes {
 		var err error
 

--- a/transform/block_index_provider.go
+++ b/transform/block_index_provider.go
@@ -12,7 +12,10 @@ import (
 	"go.uber.org/zap"
 )
 
-type BitmapGetter func(string) *roaring64.Bitmap
+type BitmapGetter interface {
+	Get(string) *roaring64.Bitmap
+	GetByPrefix(string) *roaring64.Bitmap
+}
 
 // GenericBlockIndexProvider responds to queries on BlockIndex
 type GenericBlockIndexProvider struct {
@@ -174,7 +177,7 @@ func (ip *GenericBlockIndexProvider) loadIndex(r io.ReadCloser, lowBlockNum, ind
 	ip.currentIndex = newIdx
 
 	// the user-provided function identifies the blockNums of interest
-	ip.currentMatchingBlocks = ip.filterFunc(ip.currentIndex.Get)
+	ip.currentMatchingBlocks = ip.filterFunc(ip.currentIndex)
 
 	return nil
 }

--- a/transform/block_index_provider_test.go
+++ b/transform/block_index_provider_test.go
@@ -61,12 +61,12 @@ func TestBlockIndexProvider_LoadRange(t *testing.T) {
 		},
 		{
 			name:                   "new with prefix matches",
-			blocks:                 testBlockValues(t, 5),
-			indexSize:              2,
+			blocks:                 testBlockValues(t, 6),
+			indexSize:              5,
 			indexShortname:         "test",
 			lowBlockNum:            10,
-			lookingForPrefixes:     []string{"aa"},
-			expectedMatchingBlocks: []uint64{10, 11},
+			lookingForPrefixes:     []string{"pref"},
+			expectedMatchingBlocks: []uint64{10, 12},
 		},
 		{
 			name:                   "new with prefix no match",

--- a/transform/block_index_provider_test.go
+++ b/transform/block_index_provider_test.go
@@ -67,10 +67,10 @@ func TestBlockIndexProvider_LoadRange(t *testing.T) {
 
 			// spawn an indexProvider with the populated dstore
 			// we provide our naive filterFunc inline
-			indexProvider := NewGenericBlockIndexProvider(indexStore, test.indexShortname, []uint64{test.indexSize}, func(getFunc BitmapGetter) (matchingBlocks []uint64) {
+			indexProvider := NewGenericBlockIndexProvider(indexStore, test.indexShortname, []uint64{test.indexSize}, func(getter BitmapGetter) (matchingBlocks []uint64) {
 				var results []uint64
 				for _, desired := range test.lookingFor {
-					if bitmap := getFunc(desired); bitmap != nil {
+					if bitmap := getter.Get(desired); bitmap != nil {
 						slice := bitmap.ToArray()[:]
 						results = append(results, slice...)
 					}
@@ -333,10 +333,10 @@ func TestBlockIndexProvider_NextMatching(t *testing.T) {
 
 			// spawn an indexProvider
 			// we provide our naive filterFunc inline
-			indexProvider := NewGenericBlockIndexProvider(indexStore, test.indexShortname, []uint64{test.indexSize}, func(getFunc BitmapGetter) (matchingBlocks []uint64) {
+			indexProvider := NewGenericBlockIndexProvider(indexStore, test.indexShortname, []uint64{test.indexSize}, func(bm BitmapGetter) (matchingBlocks []uint64) {
 				var results []uint64
 				for _, desired := range test.lookingFor {
-					if bitmap := getFunc(desired); bitmap != nil {
+					if bitmap := bm.Get(desired); bitmap != nil {
 						slice := bitmap.ToArray()[:]
 						results = append(results, slice...)
 					}

--- a/transform/block_index_provider_test.go
+++ b/transform/block_index_provider_test.go
@@ -30,6 +30,7 @@ func TestBlockIndexProvider_LoadRange(t *testing.T) {
 		lowBlockNum            uint64
 		lookingFor             []string
 		lookingForPrefixes     []string
+		lookingForSuffixes     []string
 		expectedMatchingBlocks []uint64
 	}{
 		{
@@ -86,6 +87,33 @@ func TestBlockIndexProvider_LoadRange(t *testing.T) {
 			lookingForPrefixes:     []string{"ddd"},
 			expectedMatchingBlocks: []uint64{11},
 		},
+		{
+			name:                   "new with suffix matches",
+			blocks:                 testBlockValues(t, 6),
+			indexSize:              5,
+			indexShortname:         "test",
+			lowBlockNum:            10,
+			lookingForSuffixes:     []string{"suffix"},
+			expectedMatchingBlocks: []uint64{10, 12},
+		},
+		{
+			name:                   "new with suffix no match",
+			blocks:                 testBlockValues(t, 5),
+			indexSize:              2,
+			indexShortname:         "test",
+			lowBlockNum:            10,
+			lookingForSuffixes:     []string{"nada"},
+			expectedMatchingBlocks: nil,
+		},
+		{
+			name:                   "new with suffix single match",
+			blocks:                 testBlockValues(t, 5),
+			indexSize:              2,
+			indexShortname:         "test",
+			lowBlockNum:            10,
+			lookingForSuffixes:     []string{"ddd"},
+			expectedMatchingBlocks: []uint64{11},
+		},
 	}
 
 	for _, test := range tests {
@@ -105,6 +133,12 @@ func TestBlockIndexProvider_LoadRange(t *testing.T) {
 				}
 				for _, desired := range test.lookingForPrefixes {
 					if bitmap := getter.GetByPrefix(desired); bitmap != nil {
+						slice := bitmap.ToArray()[:]
+						results = append(results, slice...)
+					}
+				}
+				for _, desired := range test.lookingForSuffixes {
+					if bitmap := getter.GetBySuffix(desired); bitmap != nil {
 						slice := bitmap.ToArray()[:]
 						results = append(results, slice...)
 					}

--- a/transform/block_index_provider_test.go
+++ b/transform/block_index_provider_test.go
@@ -29,6 +29,7 @@ func TestBlockIndexProvider_LoadRange(t *testing.T) {
 		indexShortname         string
 		lowBlockNum            uint64
 		lookingFor             []string
+		lookingForPrefixes     []string
 		expectedMatchingBlocks []uint64
 	}{
 		{
@@ -55,8 +56,35 @@ func TestBlockIndexProvider_LoadRange(t *testing.T) {
 			indexSize:              2,
 			indexShortname:         "test",
 			lowBlockNum:            10,
-			lookingFor:             []string{"0xDEADBEEF"},
+			lookingFor:             []string{"DEADBEEF"},
 			expectedMatchingBlocks: nil,
+		},
+		{
+			name:                   "new with prefix matches",
+			blocks:                 testBlockValues(t, 5),
+			indexSize:              2,
+			indexShortname:         "test",
+			lowBlockNum:            10,
+			lookingForPrefixes:     []string{"aa"},
+			expectedMatchingBlocks: []uint64{10, 11},
+		},
+		{
+			name:                   "new with prefix no match",
+			blocks:                 testBlockValues(t, 5),
+			indexSize:              2,
+			indexShortname:         "test",
+			lowBlockNum:            10,
+			lookingForPrefixes:     []string{"nada"},
+			expectedMatchingBlocks: nil,
+		},
+		{
+			name:                   "new with prefix single match",
+			blocks:                 testBlockValues(t, 5),
+			indexSize:              2,
+			indexShortname:         "test",
+			lowBlockNum:            10,
+			lookingForPrefixes:     []string{"ddd"},
+			expectedMatchingBlocks: []uint64{11},
 		},
 	}
 
@@ -75,6 +103,13 @@ func TestBlockIndexProvider_LoadRange(t *testing.T) {
 						results = append(results, slice...)
 					}
 				}
+				for _, desired := range test.lookingForPrefixes {
+					if bitmap := getter.GetByPrefix(desired); bitmap != nil {
+						slice := bitmap.ToArray()[:]
+						results = append(results, slice...)
+					}
+				}
+
 				return results
 			})
 			require.NotNil(t, indexProvider)

--- a/transform/testing.go
+++ b/transform/testing.go
@@ -1,11 +1,12 @@
 package transform
 
 import (
-	"github.com/streamingfast/dstore"
-	"github.com/stretchr/testify/require"
 	"io"
 	"io/ioutil"
 	"testing"
+
+	"github.com/streamingfast/dstore"
+	"github.com/stretchr/testify/require"
 )
 
 // testMockstoreWithFiles will populate a MockStore with indexes of the provided Blocks, according to the provided indexSize
@@ -47,6 +48,7 @@ func testBlockValues(t *testing.T, size int) []map[uint64][]string {
 				"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 				"3333333333333333333333333333333333333333",
 				"cccccccccccccccccccccccccccccccccccccccc",
+				"prefzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz",
 			},
 		},
 		{
@@ -61,6 +63,7 @@ func testBlockValues(t *testing.T, size int) []map[uint64][]string {
 				"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 				"1111111111111111111111111111111111111111",
 				"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+				"prefwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwww",
 			},
 		},
 		{
@@ -76,6 +79,9 @@ func testBlockValues(t *testing.T, size int) []map[uint64][]string {
 				"7777777777777777777777777777777777777777",
 				"3333333333333333333333333333333333333333",
 			},
+		},
+		{
+			15: {},
 		},
 	}
 

--- a/transform/testing.go
+++ b/transform/testing.go
@@ -48,7 +48,7 @@ func testBlockValues(t *testing.T, size int) []map[uint64][]string {
 				"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 				"3333333333333333333333333333333333333333",
 				"cccccccccccccccccccccccccccccccccccccccc",
-				"prefzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz",
+				"prefzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzsuffix",
 			},
 		},
 		{
@@ -63,7 +63,7 @@ func testBlockValues(t *testing.T, size int) []map[uint64][]string {
 				"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 				"1111111111111111111111111111111111111111",
 				"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-				"prefwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwww",
+				"prefwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwsuffix",
 			},
 		},
 		{


### PR DESCRIPTION
Changed the `BitmapGetter` interface in the signature of the `filterfunc` that must be provided when creating a GenericBlockIndexProvider: it now has `Get()` and the new `GetByPrefix`and `GetBySuffix` method, to allow getting a combined Roaring64 bitmap from all matching keys