### PR TITLE
change Prefix/Suffix index fetching to work together

### DIFF
--- a/transform/block_index.go
+++ b/transform/block_index.go
@@ -35,27 +35,18 @@ func (i *blockIndex) Get(key string) *roaring64.Bitmap {
 	return i.kv[key]
 }
 
-func (i *blockIndex) GetByPrefix(prefix string) *roaring64.Bitmap {
-	var matching []*roaring64.Bitmap
-	for k, v := range i.kv {
-		if strings.HasPrefix(k, prefix) {
-			matching = append(matching, v)
-		}
-	}
-	switch len(matching) {
-	case 0:
+func (i *blockIndex) GetByPrefixAndSuffix(prefix, suffix string) *roaring64.Bitmap {
+	if prefix == "" && suffix == "" {
+		zlog.Warn("blockIndex.GetByPrefixAndSuffix called with empty prefix and suffix, ignoring filter")
 		return nil
-	case 1:
-		return matching[0]
 	}
-	return roaring64.FastOr(matching...)
-}
 
-func (i *blockIndex) GetBySuffix(suffix string) *roaring64.Bitmap {
 	var matching []*roaring64.Bitmap
 	for k, v := range i.kv {
-		if strings.HasSuffix(k, suffix) {
-			matching = append(matching, v)
+		if prefix == "" || strings.HasPrefix(k, prefix) {
+			if suffix == "" || strings.HasSuffix(k, suffix) {
+				matching = append(matching, v)
+			}
 		}
 	}
 	switch len(matching) {

--- a/transform/block_index_provider.go
+++ b/transform/block_index_provider.go
@@ -14,8 +14,7 @@ import (
 
 type BitmapGetter interface {
 	Get(string) *roaring64.Bitmap
-	GetByPrefix(string) *roaring64.Bitmap
-	GetBySuffix(string) *roaring64.Bitmap
+	GetByPrefixAndSuffix(prefix string, suffix string) *roaring64.Bitmap
 }
 
 // GenericBlockIndexProvider responds to queries on BlockIndex


### PR DESCRIPTION
Changed the implementation so that prefix/suffix can be bundled together:

* checking a prefix: `GetByPrefixAndSuffix(prefix, "")`
* checking a suffix: `GetByPrefixAndSuffix("",suffix)`
* checking match of both prefix and suffix: `GetByPrefixAndSuffix(prefix, suffix)`

of course, the implementation can use `FastOr()` or `FastAnd()` method on the result of those calls.

Note that:
1. `GetByPrefixAndSuffix(prefix, "") AND GetByPrefixAndSuffix("",suffix)`

does not yield the same results as

2. `GetByPrefixAndSuffix(prefix, suffix)`

The first one is a logical AND on the key itself
The second one is a logical AND on the block numbers that contains keys with the correct prefix and keys with the correct suffix, not necessarily on the same key.
