### PR TITLE
Feature/source through cursor

### DIFF
--- a/filesource.go
+++ b/filesource.go
@@ -177,7 +177,7 @@ func NewFileSourceFromCursor(
 	options ...FileSourceOption,
 ) *FileSource {
 
-	wrappedHandler := newCursorResolverHandler(forkedBlocksStore, cursor, h, logger)
+	wrappedHandler := newCursorResolverHandler(forkedBlocksStore, cursor, false, h, logger)
 
 	// first block after cursor's block/lib will be sent even if they don't match filter
 	// cursor's block/lib also need to match
@@ -207,7 +207,7 @@ func NewFileSourceThroughCursor(
 	options ...FileSourceOption,
 ) *FileSource {
 
-	wrappedHandler := newCursorResolverHandler(forkedBlocksStore, cursor, h, logger)
+	wrappedHandler := newCursorResolverHandler(forkedBlocksStore, cursor, true, h, logger)
 
 	// first block after cursor's block/lib will be sent even if they don't match filter
 	// cursor's block/lib also need to match

--- a/filesource.go
+++ b/filesource.go
@@ -156,6 +156,18 @@ func (g *FileSourceFactory) SourceFromCursor(cursor *Cursor, h Handler) Source {
 	)
 }
 
+func (g *FileSourceFactory) SourceThroughCursor(start uint64, cursor *Cursor, h Handler) Source {
+	return NewFileSourceThroughCursor(
+		g.mergedBlocksStore,
+		g.forkedBlocksStore,
+		start,
+		cursor,
+		h,
+		g.logger,
+		g.options...,
+	)
+}
+
 func NewFileSourceFromCursor(
 	mergedBlocksStore dstore.Store,
 	forkedBlocksStore dstore.Store,
@@ -179,6 +191,37 @@ func NewFileSourceFromCursor(
 	return NewFileSource(
 		mergedBlocksStore,
 		cursor.LIB.Num(),
+		wrappedHandler,
+		logger,
+		tweakedOptions...)
+
+}
+
+func NewFileSourceThroughCursor(
+	mergedBlocksStore dstore.Store,
+	forkedBlocksStore dstore.Store,
+	startBlockNum uint64,
+	cursor *Cursor,
+	h Handler,
+	logger *zap.Logger,
+	options ...FileSourceOption,
+) *FileSource {
+
+	wrappedHandler := newCursorResolverHandler(forkedBlocksStore, cursor, h, logger)
+
+	// first block after cursor's block/lib will be sent even if they don't match filter
+	// cursor's block/lib also need to match
+	tweakedOptions := append(options, FileSourceWithWhitelistedBlocks(
+		startBlockNum,
+		cursor.LIB.Num(),
+		cursor.LIB.Num()+1,
+		cursor.Block.Num(),
+		cursor.Block.Num()+1,
+	))
+
+	return NewFileSource(
+		mergedBlocksStore,
+		startBlockNum,
 		wrappedHandler,
 		logger,
 		tweakedOptions...)

--- a/forkable/forkable.go
+++ b/forkable/forkable.go
@@ -108,6 +108,17 @@ func (p *Forkable) CallWithBlocksFromCursor(cursor *bstream.Cursor, callback fun
 	return nil
 }
 
+func (p *Forkable) CallWithBlocksThroughCursor(startBlock uint64, cursor *bstream.Cursor, callback func([]*bstream.PreprocessedBlock)) error {
+	p.RLock()
+	defer p.RUnlock()
+	blks, err := p.blocksThroughCursor(startBlock, cursor)
+	if err != nil {
+		return err
+	}
+	callback(blks)
+	return nil
+}
+
 // blocksFromNumWithForks will *NOT* output information about steps
 func (p *Forkable) blocksFromNumWithForks(startNum uint64) ([]*bstream.PreprocessedBlock, error) {
 	if !p.forkDB.HasLIB() {
@@ -295,6 +306,90 @@ func (p *Forkable) blocksFromCursor(cursor *bstream.Cursor) ([]*bstream.Preproce
 	}
 
 	return append(undos, newBlocks...), nil
+}
+
+func (p *Forkable) blocksThroughCursor(startBlock uint64, cursor *bstream.Cursor) ([]*bstream.PreprocessedBlock, error) {
+	if !p.forkDB.HasLIB() {
+		return nil, fmt.Errorf("no lib")
+	}
+
+	head := p.lastBlockSent.AsRef()
+	seg, reachLIB := p.forkDB.CompleteSegment(head)
+	if !reachLIB {
+		return nil, fmt.Errorf("head segment does not reach LIB")
+	}
+	if len(seg) == 0 {
+		return nil, fmt.Errorf("no complete segment")
+	}
+
+	if seg[0].BlockNum > startBlock {
+		return nil, fmt.Errorf("startBlock not contained in segment")
+	}
+	libRef := p.forkDB.libRef
+	if blockIn(cursor.Block.ID(), seg) {
+		out := []*bstream.PreprocessedBlock{}
+		for i := range seg {
+			if seg[i].BlockNum < startBlock {
+				continue
+			}
+
+			stepType := bstream.StepNew
+			if seg[i].BlockNum <= libRef.Num() {
+				stepType = bstream.StepNewIrreversible
+			}
+
+			out = append(out, wrapBlockForkableObject(seg[i].Object.(*ForkableBlock), stepType, head, libRef))
+			continue
+		}
+		return out, nil
+	}
+
+	seg, reachLIB = p.forkDB.CompleteSegment(cursor.Block)
+	if !reachLIB {
+		return nil, fmt.Errorf("head segment does not reach LIB")
+	}
+	if len(seg) == 0 {
+		return nil, fmt.Errorf("no complete segment")
+	}
+	if startBlock < seg[0].BlockNum {
+		return nil, fmt.Errorf("complete segment does not include startBlock %d (lowest segment block: %d)", startBlock, seg[0].BlockNum)
+	}
+
+	var matched bool
+	out := []*bstream.PreprocessedBlock{}
+	for i := range seg {
+		if seg[i].BlockNum < startBlock {
+			continue
+		}
+
+		stepType := bstream.StepNew
+		if seg[i].BlockNum <= cursor.LIB.Num() {
+			stepType = bstream.StepNewIrreversible
+		}
+
+		block := seg[i].Object.(*ForkableBlock)
+
+		if block.Block.Number < cursor.Block.Num() ||
+			block.Block.Number == cursor.Block.Num() && !cursor.Step.Matches(bstream.StepUndo) {
+			out = append(out, wrapBlockForkableObject(block, stepType, head, cursor.LIB))
+		}
+
+		if block.Block.Number == cursor.Block.Num() {
+			matched = true
+			break
+		}
+	}
+	if !matched {
+		return nil, fmt.Errorf("error in blocksThroughCursor, cannot match requested block. This is likely a bug.")
+	}
+
+	backToCanonical, err := p.blocksFromCursor(cursor)
+	if err != nil {
+		return nil, err
+	}
+
+	out = append(out, backToCanonical...)
+	return out, nil
 }
 
 func wrapBlockForkableObject(blk *ForkableBlock, step bstream.StepType, head bstream.BlockRef, lib bstream.BlockRef) *bstream.PreprocessedBlock {

--- a/hub/hub.go
+++ b/hub/hub.go
@@ -209,6 +209,11 @@ func (h *ForkableHub) SourceThroughCursor(startBlock uint64, cursor *bstream.Cur
 		return nil
 	}
 
+	// cursor has already passed, ignoring it
+	if cursor.Block.Num() < startBlock {
+		return h.SourceFromBlockNum(startBlock, handler)
+	}
+
 	err := h.forkable.CallWithBlocksThroughCursor(startBlock, cursor, func(blocks []*bstream.PreprocessedBlock) { // Running callback func while forkable is locked
 		out = h.subscribe(handler, blocks)
 	})

--- a/hub/hub.go
+++ b/hub/hub.go
@@ -204,6 +204,21 @@ func (h *ForkableHub) SourceFromCursor(cursor *bstream.Cursor, handler bstream.H
 	return
 }
 
+func (h *ForkableHub) SourceThroughCursor(startBlock uint64, cursor *bstream.Cursor, handler bstream.Handler) (out bstream.Source) {
+	if h == nil {
+		return nil
+	}
+
+	err := h.forkable.CallWithBlocksThroughCursor(startBlock, cursor, func(blocks []*bstream.PreprocessedBlock) { // Running callback func while forkable is locked
+		out = h.subscribe(handler, blocks)
+	})
+	if err != nil {
+		zlog.Debug("error getting source_from_cursor", zap.Error(err))
+		return nil
+	}
+	return
+}
+
 func (h *ForkableHub) bootstrap(blk *bstream.Block) error {
 
 	// don't try bootstrapping from one-block-files if we are not at HEAD

--- a/hub/hub_test.go
+++ b/hub/hub_test.go
@@ -843,6 +843,22 @@ func TestForkableHub_SourceThroughCursor(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "start block too low no source",
+			forkdbBlocks: []*bstream.Block{
+				bstream.TestBlockWithLIBNum("00000003a", "00000002a", 2),
+				bstream.TestBlockWithLIBNum("00000004a", "00000003a", 2),
+				bstream.TestBlockWithLIBNum("00000005a", "00000004a", 3),
+			},
+			requestCursor: &bstream.Cursor{
+				Step:      bstream.StepNew,
+				Block:     bstream.NewBlockRef("00000005a", 5),
+				HeadBlock: bstream.NewBlockRef("00000005a", 5),
+				LIB:       bstream.NewBlockRef("00000003a", 3),
+			},
+			requestStartBlock: 2,
+			expectBlocks:      nil,
+		},
 	}
 
 	for _, test := range tests {

--- a/hub/hub_test.go
+++ b/hub/hub_test.go
@@ -588,3 +588,305 @@ func TestForkableHub_SourceFromCursor(t *testing.T) {
 		})
 	}
 }
+
+func TestForkableHub_SourceThroughCursor(t *testing.T) {
+
+	type expectedBlock struct {
+		block        *bstream.Block
+		step         bstream.StepType
+		cursorLibNum uint64
+	}
+
+	tests := []struct {
+		name              string
+		forkdbBlocks      []*bstream.Block
+		requestCursor     *bstream.Cursor
+		requestStartBlock uint64
+		expectBlocks      []expectedBlock
+	}{
+		{
+			name: "through canonical cursor",
+			forkdbBlocks: []*bstream.Block{
+				bstream.TestBlockWithLIBNum("00000003a", "00000002a", 2),
+				bstream.TestBlockWithLIBNum("00000004a", "00000003a", 2),
+				bstream.TestBlockWithLIBNum("00000004b", "00000003a", 2), //fork
+				bstream.TestBlockWithLIBNum("00000005a", "00000004a", 3),
+				bstream.TestBlockWithLIBNum("00000008a", "00000005a", 3),
+			},
+			requestCursor: &bstream.Cursor{
+				Step:      bstream.StepNew,
+				Block:     bstream.NewBlockRef("00000004a", 4),
+				HeadBlock: bstream.NewBlockRef("00000005a", 5),
+				LIB:       bstream.NewBlockRef("00000003a", 3),
+			},
+			requestStartBlock: 3,
+			expectBlocks: []expectedBlock{
+				{
+					bstream.TestBlockWithLIBNum("00000003a", "00000002a", 2),
+					bstream.StepNewIrreversible,
+					3,
+				},
+				{
+					bstream.TestBlockWithLIBNum("00000004a", "00000003a", 2),
+					bstream.StepNew,
+					3,
+				},
+				{
+					bstream.TestBlockWithLIBNum("00000005a", "00000004a", 3),
+					bstream.StepNew,
+					3,
+				},
+				{
+					bstream.TestBlockWithLIBNum("00000008a", "00000005a", 3),
+					bstream.StepNew,
+					3,
+				},
+			},
+		},
+		{
+			name: "through canonical undo cursor",
+			forkdbBlocks: []*bstream.Block{
+				bstream.TestBlockWithLIBNum("00000003a", "00000002a", 2),
+				bstream.TestBlockWithLIBNum("00000004a", "00000003a", 2),
+				bstream.TestBlockWithLIBNum("00000004b", "00000003a", 2), //fork
+				bstream.TestBlockWithLIBNum("00000005a", "00000004a", 3),
+				bstream.TestBlockWithLIBNum("00000008a", "00000005a", 3),
+			},
+			requestCursor: &bstream.Cursor{
+				Step:      bstream.StepUndo,
+				Block:     bstream.NewBlockRef("00000004a", 4),
+				HeadBlock: bstream.NewBlockRef("00000005a", 5),
+				LIB:       bstream.NewBlockRef("00000003a", 3),
+			},
+			requestStartBlock: 3,
+			expectBlocks: []expectedBlock{
+				{
+					bstream.TestBlockWithLIBNum("00000003a", "00000002a", 2),
+					bstream.StepNewIrreversible,
+					3,
+				},
+				{
+					bstream.TestBlockWithLIBNum("00000004a", "00000003a", 2),
+					bstream.StepNew,
+					3,
+				},
+				{
+					bstream.TestBlockWithLIBNum("00000005a", "00000004a", 3),
+					bstream.StepNew,
+					3,
+				},
+				{
+					bstream.TestBlockWithLIBNum("00000008a", "00000005a", 3),
+					bstream.StepNew,
+					3,
+				},
+			},
+		},
+		{
+			name: "through non-canonical cursor",
+			forkdbBlocks: []*bstream.Block{
+				bstream.TestBlockWithLIBNum("00000003a", "00000002a", 2),
+				bstream.TestBlockWithLIBNum("00000004a", "00000003a", 2),
+				bstream.TestBlockWithLIBNum("00000004b", "00000003a", 2), //fork
+				bstream.TestBlockWithLIBNum("00000005a", "00000004a", 3),
+				bstream.TestBlockWithLIBNum("00000008a", "00000005a", 3),
+			},
+			requestCursor: &bstream.Cursor{
+				Step:      bstream.StepNew,
+				Block:     bstream.NewBlockRef("00000004b", 4),
+				HeadBlock: bstream.NewBlockRef("00000004b", 4),
+				LIB:       bstream.NewBlockRef("00000003a", 3),
+			},
+			requestStartBlock: 3,
+			expectBlocks: []expectedBlock{
+				{
+					bstream.TestBlockWithLIBNum("00000003a", "00000002a", 2),
+					bstream.StepNewIrreversible,
+					3,
+				},
+				{
+					bstream.TestBlockWithLIBNum("00000004b", "00000003a", 2),
+					bstream.StepNew,
+					3,
+				},
+				{
+					bstream.TestBlockWithLIBNum("00000004b", "00000003a", 2),
+					bstream.StepUndo,
+					3,
+				},
+				{
+					bstream.TestBlockWithLIBNum("00000004a", "00000003a", 2),
+					bstream.StepNew,
+					3,
+				},
+				{
+					bstream.TestBlockWithLIBNum("00000005a", "00000004a", 3),
+					bstream.StepNew,
+					3,
+				},
+				{
+					bstream.TestBlockWithLIBNum("00000008a", "00000005a", 3),
+					bstream.StepNew,
+					3,
+				},
+			},
+		},
+		{
+			name: "through deep non-canonical cursor",
+			forkdbBlocks: []*bstream.Block{
+				bstream.TestBlockWithLIBNum("00000003a", "00000002a", 2),
+				bstream.TestBlockWithLIBNum("00000004a", "00000003a", 2),
+				bstream.TestBlockWithLIBNum("00000004b", "00000003a", 2), //fork
+				bstream.TestBlockWithLIBNum("00000005b", "00000004b", 2), //fork
+				bstream.TestBlockWithLIBNum("00000005a", "00000004a", 3),
+				bstream.TestBlockWithLIBNum("00000008a", "00000005a", 3),
+			},
+			requestCursor: &bstream.Cursor{
+				Step:      bstream.StepNew,
+				Block:     bstream.NewBlockRef("00000005b", 5),
+				HeadBlock: bstream.NewBlockRef("00000005b", 5),
+				LIB:       bstream.NewBlockRef("00000003a", 3),
+			},
+			requestStartBlock: 3,
+			expectBlocks: []expectedBlock{
+				{
+					bstream.TestBlockWithLIBNum("00000003a", "00000002a", 2),
+					bstream.StepNewIrreversible,
+					3,
+				},
+				{
+					bstream.TestBlockWithLIBNum("00000004b", "00000003a", 2),
+					bstream.StepNew,
+					3,
+				},
+				{
+					bstream.TestBlockWithLIBNum("00000005b", "00000004b", 2),
+					bstream.StepNew,
+					3,
+				},
+				{
+					bstream.TestBlockWithLIBNum("00000005b", "00000004b", 2),
+					bstream.StepUndo,
+					3,
+				},
+
+				{
+					bstream.TestBlockWithLIBNum("00000004b", "00000003a", 2),
+					bstream.StepUndo,
+					3,
+				},
+				{
+					bstream.TestBlockWithLIBNum("00000004a", "00000003a", 2),
+					bstream.StepNew,
+					3,
+				},
+				{
+					bstream.TestBlockWithLIBNum("00000005a", "00000004a", 3),
+					bstream.StepNew,
+					3,
+				},
+				{
+					bstream.TestBlockWithLIBNum("00000008a", "00000005a", 3),
+					bstream.StepNew,
+					3,
+				},
+			},
+		},
+		{
+			name: "through deep non-canonical UNDO cursor",
+			forkdbBlocks: []*bstream.Block{
+				bstream.TestBlockWithLIBNum("00000003a", "00000002a", 2),
+				bstream.TestBlockWithLIBNum("00000004a", "00000003a", 2),
+				bstream.TestBlockWithLIBNum("00000004b", "00000003a", 2), //fork
+				bstream.TestBlockWithLIBNum("00000005b", "00000004b", 2), //fork
+				bstream.TestBlockWithLIBNum("00000005a", "00000004a", 3),
+				bstream.TestBlockWithLIBNum("00000008a", "00000005a", 3),
+			},
+			requestCursor: &bstream.Cursor{
+				Step:      bstream.StepUndo,
+				Block:     bstream.NewBlockRef("00000005b", 5),
+				HeadBlock: bstream.NewBlockRef("00000005b", 5),
+				LIB:       bstream.NewBlockRef("00000003a", 3),
+			},
+			requestStartBlock: 3,
+			expectBlocks: []expectedBlock{
+				{
+					bstream.TestBlockWithLIBNum("00000003a", "00000002a", 2),
+					bstream.StepNewIrreversible,
+					3,
+				},
+				{
+					bstream.TestBlockWithLIBNum("00000004b", "00000003a", 2),
+					bstream.StepNew,
+					3,
+				},
+
+				{
+					bstream.TestBlockWithLIBNum("00000004b", "00000003a", 2),
+					bstream.StepUndo,
+					3,
+				},
+				{
+					bstream.TestBlockWithLIBNum("00000004a", "00000003a", 2),
+					bstream.StepNew,
+					3,
+				},
+				{
+					bstream.TestBlockWithLIBNum("00000005a", "00000004a", 3),
+					bstream.StepNew,
+					3,
+				},
+				{
+					bstream.TestBlockWithLIBNum("00000008a", "00000005a", 3),
+					bstream.StepNew,
+					3,
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fh := &ForkableHub{
+				Shutter: shutter.New(),
+			}
+			fh.forkable = forkable.New(bstream.HandlerFunc(fh.processBlock),
+				forkable.HoldBlocksUntilLIB(),
+				forkable.WithKeptFinalBlocks(100),
+			)
+			fh.ready = true
+
+			for _, blk := range test.forkdbBlocks {
+				require.NoError(t, fh.forkable.ProcessBlock(blk, nil))
+			}
+
+			var seenBlocks []expectedBlock
+			handler := bstream.HandlerFunc(func(blk *bstream.Block, obj interface{}) error {
+				seenBlocks = append(seenBlocks, expectedBlock{blk, obj.(*forkable.ForkableObject).Step(), obj.(*forkable.ForkableObject).Cursor().LIB.Num()})
+				if len(seenBlocks) == len(test.expectBlocks) {
+					return fmt.Errorf("done")
+				}
+				return nil
+			})
+
+			source := fh.SourceThroughCursor(test.requestStartBlock, test.requestCursor, handler)
+			if test.expectBlocks == nil {
+				assert.Nil(t, source)
+				return
+			}
+
+			require.NotNil(t, source)
+
+			if len(test.expectBlocks) == 0 {
+				return // we get an empty source for now, until live blocks come in
+			}
+			go source.Run()
+			select {
+			case <-source.Terminating():
+				assert.Equal(t, test.expectBlocks, seenBlocks)
+			case <-time.After(time.Second):
+				t.Errorf("timeout waiting for blocks")
+			}
+		})
+	}
+}

--- a/interfaces.go
+++ b/interfaces.go
@@ -64,6 +64,7 @@ type ObjectWrapper interface {
 type ForkableSourceFactory interface {
 	SourceFromBlockNum(uint64, Handler) Source // irreversible
 	SourceFromCursor(*Cursor, Handler) Source
+	SourceThroughCursor(uint64, *Cursor, Handler) Source
 }
 
 type LowSourceLimitGetter interface {

--- a/joiningsource.go
+++ b/joiningsource.go
@@ -130,9 +130,16 @@ func (s *JoiningSource) fileSourceHandler(blk *Block, obj interface{}) error {
 	}
 
 	if blk.Number >= s.lowestLiveBlockNum {
-		if src := s.liveSourceFactory.SourceFromBlockNum(blk.Number, s.handler); src != nil {
-			s.liveSource = src
-			return stopSourceOnJoin
+		if s.cursorIsTarget {
+			if src := s.liveSourceFactory.SourceThroughCursor(blk.Number, s.cursor, s.handler); src != nil {
+				s.liveSource = src
+				return stopSourceOnJoin
+			}
+		} else {
+			if src := s.liveSourceFactory.SourceFromBlockNum(blk.Number, s.handler); src != nil {
+				s.liveSource = src
+				return stopSourceOnJoin
+			}
 		}
 		if lowestBlockGetter, ok := s.liveSourceFactory.(LowSourceLimitGetter); ok {
 			s.lowestLiveBlockNum = lowestBlockGetter.LowestBlockNum()

--- a/joiningsource.go
+++ b/joiningsource.go
@@ -44,8 +44,9 @@ type JoiningSource struct {
 
 	lastBlockProcessed *Block
 
-	startBlockNum uint64 // overriden by cursor if it exists
-	cursor        *Cursor
+	startBlockNum  uint64 // overriden by cursor if it exists, unless we are in cursorIsTarget mode
+	cursor         *Cursor
+	cursorIsTarget bool
 
 	logger *zap.Logger
 }
@@ -56,6 +57,7 @@ func NewJoiningSource(
 	h Handler,
 	startBlockNum uint64,
 	cursor *Cursor,
+	cursorIsTarget bool,
 	logger *zap.Logger) *JoiningSource {
 	logger.Info("creating new joining source", zap.Stringer("cursor", cursor), zap.Uint64("start_block_num", startBlockNum))
 
@@ -66,6 +68,7 @@ func NewJoiningSource(
 		handler:           h,
 		startBlockNum:     startBlockNum,
 		cursor:            cursor,
+		cursorIsTarget:    cursorIsTarget,
 		logger:            logger,
 	}
 
@@ -113,6 +116,9 @@ func (s *JoiningSource) run() error {
 
 func (s *JoiningSource) tryGetSource(handler Handler, factory ForkableSourceFactory) Source {
 	if s.cursor != nil {
+		if s.cursorIsTarget {
+			return factory.SourceThroughCursor(s.startBlockNum, s.cursor, handler)
+		}
 		return factory.SourceFromCursor(s.cursor, handler)
 	}
 	return factory.SourceFromBlockNum(s.startBlockNum, handler)

--- a/joiningsource_test.go
+++ b/joiningsource_test.go
@@ -57,7 +57,7 @@ func TestJoiningSource_vanilla(t *testing.T) {
 		return nil
 	}
 
-	joiningSource := NewJoiningSource(fileSF, liveSF, handler, 2, nil, zlog)
+	joiningSource := NewJoiningSource(fileSF, liveSF, handler, 2, nil, false, zlog)
 	go joiningSource.Run()
 
 	fileSrc := <-fileSF.Created
@@ -90,7 +90,7 @@ func TestJoiningSource_skip_file_source(t *testing.T) {
 
 	handler, out := testHandler(0)
 
-	joiningSource := NewJoiningSource(fileSF, liveSF, handler, 2, nil, zlog)
+	joiningSource := NewJoiningSource(fileSF, liveSF, handler, 2, nil, false, zlog)
 	go joiningSource.Run()
 
 	liveSrc := <-liveSF.Created
@@ -129,7 +129,7 @@ func TestJoiningSource_lowerLimitBackoff(t *testing.T) {
 		return nil
 	}
 
-	joiningSource := NewJoiningSource(fileSF, liveSF, handler, 1, nil, zlog)
+	joiningSource := NewJoiningSource(fileSF, liveSF, handler, 1, nil, false, zlog)
 	go joiningSource.Run()
 
 	fileSrc := <-fileSF.Created

--- a/joiningsource_test.go
+++ b/joiningsource_test.go
@@ -84,6 +84,59 @@ func TestJoiningSource_vanilla(t *testing.T) {
 	<-joiningSource.Terminated()
 }
 
+func TestJoiningSource_through_cursor(t *testing.T) {
+	joiningBlock := uint64(6)
+	failingBlock := uint64(9999)
+	fileSF := NewTestSourceFactory()
+	liveSF := NewTestSourceFactory()
+	cursor := &Cursor{
+		Step:      StepNew,
+		Block:     NewBlockRefFromID("00000005"),
+		HeadBlock: NewBlockRefFromID("00000005"),
+		LIB:       NewBlockRefFromID("00000003"),
+	}
+	startBlock := uint64(3)
+
+	var liveSrc *TestSource
+	handler, out := testHandler(failingBlock)
+	liveSF.ThroughCursorFunc = func(start uint64, cursor *Cursor, h Handler) Source {
+		if start == joiningBlock {
+			src := NewTestSource(h)
+			src.Cursor = cursor
+			src.StartBlockNum = start
+			src.PassThroughCursor = true
+			liveSrc = src
+			return src
+		}
+		return nil
+	}
+
+	joiningSource := NewJoiningSource(fileSF, liveSF, handler, startBlock, cursor, true, zlog)
+	go joiningSource.Run()
+
+	fileSrc := <-fileSF.Created
+	<-fileSrc.running // test fixture ready to push blocks
+	assert.Equal(t, uint64(3), fileSrc.StartBlockNum)
+	assert.Equal(t, cursor, fileSrc.Cursor)
+	assert.True(t, fileSrc.PassThroughCursor)
+
+	require.NoError(t, fileSrc.Push(TestBlock("00000003a", "00000002a"), nil))
+	require.NoError(t, fileSrc.Push(TestBlock("00000004a", "00000003a"), nil))
+	require.NoError(t, fileSrc.Push(TestBlock("00000005a", "00000004a"), nil))
+	require.EqualError(t, fileSrc.Push(TestBlock("00000006a", "00000005a"), nil), stopSourceOnJoin.Error())
+
+	<-fileSrc.Terminated()       // previous error causes termination
+	assert.Equal(t, 3, len(out)) // 3, 4, 5 (6 will be sent by live)
+
+	require.NotNil(t, liveSrc, "we should have joined to live source")
+	assert.Equal(t, uint64(6), liveSrc.StartBlockNum)
+	assert.Equal(t, cursor, liveSrc.Cursor)
+	assert.True(t, liveSrc.PassThroughCursor)
+
+	require.NoError(t, liveSrc.Push(TestBlock("00000006a", "00000005a"), nil))
+	assert.Equal(t, 4, len(out))
+}
+
 func TestJoiningSource_skip_file_source(t *testing.T) {
 	var fileSF ForkableSourceFactory //not used
 	liveSF := NewTestSourceFactory()

--- a/stream/options.go
+++ b/stream/options.go
@@ -49,6 +49,12 @@ func WithCursor(cursor *bstream.Cursor) Option {
 		s.cursor = cursor
 	}
 }
+func WithTargetCursor(cursor *bstream.Cursor) Option {
+	return func(s *Stream) {
+		s.cursor = cursor
+		s.cursorIsTarget = true
+	}
+}
 
 func WithStopBlock(stopBlockNum uint64) Option { //inclusive
 	return func(s *Stream) {

--- a/stream/stream.go
+++ b/stream/stream.go
@@ -20,8 +20,9 @@ type Stream struct {
 	startBlockNum int64
 	handler       bstream.Handler
 
-	cursor       *bstream.Cursor
-	stopBlockNum uint64
+	cursor         *bstream.Cursor
+	cursorIsTarget bool
+	stopBlockNum   uint64
 
 	preprocessFunc    bstream.PreprocessFunc
 	preprocessThreads int
@@ -144,6 +145,7 @@ func (s *Stream) createSource() (bstream.Source, error) {
 		h,
 		absoluteStartBlockNum,
 		s.cursor,
+		s.cursorIsTarget,
 		s.logger,
 	), nil
 

--- a/testing.go
+++ b/testing.go
@@ -59,10 +59,11 @@ func bRef(id string) BlockRef {
 }
 
 type TestSourceFactory struct {
-	Created          chan *TestSource
-	FromBlockNumFunc func(uint64, Handler) Source
-	FromCursorFunc   func(*Cursor, Handler) Source
-	LowestBlkNum     uint64
+	Created           chan *TestSource
+	FromBlockNumFunc  func(uint64, Handler) Source
+	FromCursorFunc    func(*Cursor, Handler) Source
+	ThroughCursorFunc func(uint64, *Cursor, Handler) Source
+	LowestBlkNum      uint64
 }
 
 func NewTestSourceFactory() *TestSourceFactory {
@@ -101,6 +102,16 @@ func (t *TestSourceFactory) SourceFromBlockNum(blockNum uint64, h Handler) Sourc
 func (t *TestSourceFactory) SourceFromCursor(cursor *Cursor, h Handler) Source {
 	if t.FromCursorFunc != nil {
 		return t.FromCursorFunc(cursor, h)
+	}
+	src := NewTestSource(h)
+	src.Cursor = cursor
+	t.Created <- src
+	return src
+}
+
+func (t *TestSourceFactory) SourceThroughCursor(start uint64, cursor *Cursor, h Handler) Source {
+	if t.ThroughCursorFunc != nil {
+		return t.ThroughCursorFunc(start, cursor, h)
 	}
 	src := NewTestSource(h)
 	src.Cursor = cursor

--- a/testing.go
+++ b/testing.go
@@ -114,7 +114,9 @@ func (t *TestSourceFactory) SourceThroughCursor(start uint64, cursor *Cursor, h 
 		return t.ThroughCursorFunc(start, cursor, h)
 	}
 	src := NewTestSource(h)
+	src.StartBlockNum = start
 	src.Cursor = cursor
+	src.PassThroughCursor = true
 	t.Created <- src
 	return src
 }
@@ -133,10 +135,11 @@ type TestSource struct {
 	logger  *zap.Logger
 	*shutter.Shutter
 
-	running       chan interface{}
-	StartBlockID  string
-	StartBlockNum uint64
-	Cursor        *Cursor
+	running           chan interface{}
+	StartBlockID      string
+	StartBlockNum     uint64
+	Cursor            *Cursor
+	PassThroughCursor bool
 }
 
 func (t *TestSource) SetLogger(logger *zap.Logger) {


### PR DESCRIPTION
Add a new feature to Hub/Filesource/stream: "SourceThroughCursor"

This allows specifying a start block AND a cursor, the source will then:
1) start at `startBlock`
2) if the cursor is in the canonical chain, it will proceed as usual, ignoring the cursor.
3) if the cursor is on a forked block, it will bring you up to that block, THEN bring you back to the canonical chain with UNDOs and such.

There are 2 CAVEATS:

i. If the cursor block is forked and a block at the same height is already in the merged-blocks ("old forked cursor"), it will bail out saying that the this fork resolution is not implemented yet.

ii. If the cursor's LIB is NOT in the hub anymore, but the cursor's block is not in the merged blocks yet, the request will stall. To prevent this when using SourceThroughCursor, make sure that your hub has "keepFinalBlocks" value that is greater than the max distance from head to LIB, + 99.