### PR TITLE
fix: check oneBlocksAboveLibRef arrays length and throw error if length is 0

### DIFF
--- a/hub/hub.go
+++ b/hub/hub.go
@@ -290,6 +290,10 @@ func (h *ForkableHub) bootstrap() error {
 		}
 	}
 
+	if len(oneBlocksAboveLibRef) == 0 {
+		return fmt.Errorf("no one blocks above libRef found")
+	}
+
 	if !h.forkable.Linkable(oneBlocksAboveLibRef[len(oneBlocksAboveLibRef)-1]) {
 		return fmt.Errorf("most recent one block is not linkable")
 	}


### PR DESCRIPTION
Check arrays length and throw an error instead of panicking.
fixes issue #38